### PR TITLE
Update docker installer script

### DIFF
--- a/installers/redhat-docker/radiasoft-download.sh
+++ b/installers/redhat-docker/radiasoft-download.sh
@@ -79,7 +79,7 @@ EOF
     mount '$data'
     install -d -m 700 /etc/docker/tls
     install -m 400 "$tmp_d/cert.pem" "$tmp_d/key.pem" /etc/docker/tls
-    install -m 400 /dev/stdin /etc/systemd/system/docker.service.d/override.conf <<'EOF2'
+    install -D -m 400 /dev/stdin /etc/systemd/system/docker.service.d/override.conf <<'EOF2'
 # https://docs.docker.com/config/daemon/#troubleshoot-conflicts-between-the-daemonjson-and-startup-scripts
 [Service]
 ExecStart=


### PR DESCRIPTION
The default docker systemd configuration now starts the daemon like:

  /usr/bin/dockerd -H unix://

This conflicts with the use of the "hosts" key in daemon.json, and
causes docker to error out on startup with the message:

  unable to configure the Docker daemon with file
  /etc/docker/daemon.json: the following directives are specified both
  as a flag and in the configuration file: hosts: (from flag:
  [unix://], from file: [tcp://localhost.localdomain:2376
  unix:///run/docker.sock])

This is well-documented in the docker manual:

  https://docs.docker.com/config/daemon/#troubleshoot-conflicts-between-the-daemonjson-and-startup-scripts

Since we want to set hosts in daemon.json, this patch adds a systemd
override file to remove the -H flag, resolving the conflict.

Also, clarified the error message giving instructions on what to do
next if selinux was enabled.

Also, replaced 'unix:///run/docker.socket' with simple 'unix://',
which means "the default socket location", i.e.
/var/run/docker.socket. This is mostly aesthetic, because on Fedora,
/run and /var/run are aliases for each other. But it makes things
slightly simpler and slightly more correct, so why not.