### PR TITLE
Fix radiasoft/sirepoflash#2. Update caplaser config.

### DIFF
--- a/installers/rpm-code/codes/flash.sh
+++ b/installers/rpm-code/codes/flash.sh
@@ -43,10 +43,11 @@ flash_setup_CapLaserBELLA() {
     local type=$1
     codes_download_proprietary "flash/$type-4.6.2.tar.gz" "source"
     cd ..
-    ./setup "$type" -objdir="$type" -auto -2d -nxb=16 -nyb=16 +hdf5typeio \
+    ./setup "$type" -objdir="$type" -auto -2d -nxb=8 -nyb=8 +hdf5typeio \
             species=fill,wall +mtmmmt +usm3t +mgd mgd_meshgroups=6 \
-            -parfile=caplaser_basic.par +laser ed_maxPulses=1 \
-            ed_maxPulseSections=4 ed_maxBeams=1
+            -parfile=bella.par +laser ed_maxPulses=1 ed_maxPulseSections=4 \
+            ed_maxBeams=1 \
+            -with-unit=physics/sourceTerms/Heatexchange/HeatexchangeMain/LeeMore
 }
 
 flash_setup_RTFlame() {


### PR DESCRIPTION
@robnagler the latest CapLaserBELLA-4.6.2.tar.gz is available. Should we automate this process so we don't have to pass files like this in the future? I built CapLaserBELLA-4.6.2.tar.gz from https://github.com/radiasoft/rsflash/tree/master/config/Bella