### PR TITLE
Fix radiasoft/sirepo#2674. Install nginx.

### DIFF
--- a/installers/fedora-dev-deprecated/radiasoft-download.sh
+++ b/installers/fedora-dev-deprecated/radiasoft-download.sh
@@ -105,7 +105,6 @@ fedora_dev_rpms() {
         lsof
         lzma-devel
         make
-        nginx
         openssl-devel
         patch
         pciutils

--- a/installers/fedora-dev/radiasoft-download.sh
+++ b/installers/fedora-dev/radiasoft-download.sh
@@ -105,6 +105,7 @@ fedora_dev_rpms() {
         lsof
         lzma-devel
         make
+        nginx
         openssl-devel
         patch
         pciutils

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -60,6 +60,7 @@ redhat_base_main() {
         lshw
         lsof
         make
+        nginx
         openssl-devel
         patch
         pciutils

--- a/installers/vagrant-rsconf-dev/radiasoft-download.sh
+++ b/installers/vagrant-rsconf-dev/radiasoft-download.sh
@@ -25,7 +25,6 @@ vagrant_rsconf_dev_master() {
     bivio_vagrant_ssh <<'EOF'
         bivio_pyenv_3
         set -euo pipefail
-        sudo yum install -y nginx
         mkdir -p ~/src/radiasoft
         cd ~/src/radiasoft
         gcl download


### PR DESCRIPTION
We no longer use the nginx docker image to run the proxy.