### PR TITLE
Fix #164: Install pyzgoubi

### DIFF
--- a/installers/rpm-code/codes/common.sh
+++ b/installers/rpm-code/codes/common.sh
@@ -27,6 +27,8 @@ common_python() {
         pandas \
         sympy \
         tables
+    # Conflict between rscode-pyzgoubi and rscode-ml so just include here
+    install_pip_install PyYAML
     # Lots of dependencies so we install here to avoid rpm collisions.
     # Slows down builds of pykern, but doesn't affect development.
     codes_download pykern

--- a/installers/rpm-code/codes/pyzgoubi.sh
+++ b/installers/rpm-code/codes/pyzgoubi.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 pyzgoubi_python_install() {
-    cd pyzgoubi
+    install_pip_install zgoubi_metadata
+    cd PyZgoubi
     codes_python_install
 }
 
 pyzgoubi_main() {
     codes_dependencies common
-    codes_download pyzgoubi py3
+    codes_download https://github.com/PyZgoubi/PyZgoubi.git
 }

--- a/installers/rpm-code/codes/zgoubi.sh
+++ b/installers/rpm-code/codes/zgoubi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 zgoubi_main() {
-    codes_dependencies common pyzgoubi
+    codes_dependencies common
     codes_download radiasoft/zgoubi
     # Lots of warnings so disable
     perl -pi -e 's{-Wall}{-w}' CMakeLists.txt


### PR DESCRIPTION
Remove the old py2 pyzgoubi and use the py3 version instead