### PR TITLE
Fix #167: update elegant to 2021.1.0

### DIFF
--- a/installers/rpm-code/codes/elegant.sh
+++ b/installers/rpm-code/codes/elegant.sh
@@ -64,7 +64,7 @@ elegant_download() {
     for f in '' /apps /apps/configure /apps/configure/os /apps/config /apps/src/utils/tools; do
         svn --non-recursive -q checkout https://svn.aps.anl.gov/AOP/oag/trunk"$f" oag"$f"
     done
-    for f in elegant.2020.4.0 SDDS.5.0 oag.1.26 epics.extensions.configure; do
+    for f in elegant.2021.1.0 SDDS.5.0 oag.1.26 epics.extensions.configure; do
         u=https://ops.aps.anl.gov/downloads/$f.tar.gz
         if [[ $f =~ ^(.+[[:alpha:]])\.([[:digit:]].+)$ ]]; then
             codes_manifest_add_code "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "$u"


### PR DESCRIPTION
@moellep this is my first time updating a code so not too sure what steps I need to take to make sure it works. I ran the tests and clicked around the app. All seemed to work.

I noticed warnings similar to these in many of the examples:
```
*** Warning: concat_order is non-zero in run_setup, which is deprecated---Using matrix concatenation is rarely needed and reduces accuracy. *** Warning: Parameter N_KICKS of CSRCSBEND is deprecated.---Element is B1. Please consult manual for details. *** Warning: Parameter N_KICKS of CSRCSBEND is deprecated.---Element is B2. Please consult manual for details. *** Warning: Parameter N_KICKS of CSRCSBEND is deprecated.---Element is B3. Please consult manual for details. *** Warning: Parameter N_KICKS of CSRCSBEND is deprecated.---Element is B4. Please consult manual for details.
```

Are they worth fixing?