### PR TITLE
Fix #171: correct path to databroker config file

### DIFF
--- a/installers/rpm-code/codes/bluesky.sh
+++ b/installers/rpm-code/codes/bluesky.sh
@@ -20,7 +20,7 @@ bluesky_main() {
 }
 
 bluesky_mongo() {
-    local d=${codes_dir[lib]}/intake
+    local d=${codes_dir[share]}/intake
     local c=rsbluesky
     local r=/var/tmp/mongodb-rsbluesky
     local s=$r/mongod.sock


### PR DESCRIPTION
sirepo-bluesky -> bluesky -> databroker -> intake -> appdirs
appdirs specifies where configuration files are stored depending
on the architecture the application is running on. On Linux it
expects configuration files in ~/.local/share.