### PR TITLE
WIP radiasoft/container-jupyter-nvidia#9: compile hypre for gpu

### DIFF
--- a/installers/rpm-code/codes/hypre.sh
+++ b/installers/rpm-code/codes/hypre.sh
@@ -2,9 +2,25 @@
 
 hypre_main() {
     codes_dependencies common
-    codes_download https://github.com/hypre-space/hypre/archive/v2.11.2.tar.gz
+    codes_download https://github.com/hypre-space/hypre/archive/v2.24.0.tar.gz
     cd src
-    ./configure --prefix="${codes_dir[prefix]}"
+    local a=''
+    if [[ ${1:-} == 'gpu-only' ]]; then
+        #POSIT: container-jupyter-nvidia (cuda-11.1)
+        # and running on Tesla V100 (arch 70)
+        a=(
+            --with-mpi
+            --enable-unified-memory
+            --prefix="${codes_dir[prefix]}"
+            --with-MPI
+            --with-cuda
+            --with-cuda-home='/usr/local/cuda-11.1'
+            --with-gpu-arch='70'
+        )
+    fi
+    ./configure \
+        --prefix="${codes_dir[prefix]}" \
+        "${a[@]}"
     # hypre install does a chmod -R on install dirs, which
     # makes a mess of things so install manually.
     codes_make all

--- a/installers/rpm-code/codes/hypre.sh
+++ b/installers/rpm-code/codes/hypre.sh
@@ -4,18 +4,15 @@ hypre_main() {
     codes_dependencies common
     codes_download https://github.com/hypre-space/hypre/archive/v2.24.0.tar.gz
     cd src
-    local a=''
+    local -a a=()
     if [[ ${1:-} == 'gpu-only' ]]; then
         #POSIT: container-jupyter-nvidia (cuda-11.1)
         # and running on Tesla V100 (arch 70)
         a=(
-            --with-mpi
             --enable-unified-memory
-            --prefix="${codes_dir[prefix]}"
-            --with-MPI
             --with-cuda
-            --with-cuda-home='/usr/local/cuda-11.1'
-            --with-gpu-arch='70'
+            --with-cuda-home=/usr/local/cuda-11.1
+            --with-gpu-arch=70
         )
     fi
     ./configure \


### PR DESCRIPTION
Same as rscode-elegant. Use the gpu-only flag to specify that gpu
specific compilation is needed.

Also, update hypre.


I tested the hypre change on opal and flash (the flash installer mentioned hypre). Both worked fine