### PR TITLE
Fix#201: build openmc

### DIFF
--- a/installers/beamsim-codes/radiasoft-download.sh
+++ b/installers/beamsim-codes/radiasoft-download.sh
@@ -24,6 +24,7 @@ beamsim_codes_main() {
         madx
         ml
         opal
+        openmc
         pydicom
         pymesh
         raydata

--- a/installers/rpm-code/codes.sh
+++ b/installers/rpm-code/codes.sh
@@ -27,7 +27,7 @@ codes_cmake_fix_lib_dir() {
     perl -pi -e '/include\(GNUInstallDirs/ && ($_ .= q{
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE PATH "Library installation directory." FORCE)
 GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_LIBDIR CMAKE_INSTALL_LIBDIR)
-})' CMakeLists.txt
+})' $(find . -name CMakeLists.txt)
 }
 
 codes_curl() {
@@ -102,6 +102,7 @@ codes_download() {
                 git clone $r -q "$repo"
                 cd "$d"
                 git checkout "$qualifier"
+                git submodule update --init --recursive
             else
                 git clone $r --depth 1 "$repo"
                 cd "$d"

--- a/installers/rpm-code/codes.sh
+++ b/installers/rpm-code/codes.sh
@@ -24,10 +24,10 @@ codes_cmake() {
 
 codes_cmake_fix_lib_dir() {
     # otherwise uses ~/.local/lib64
-    perl -pi -e '/include\(GNUInstallDirs/ && ($_ .= q{
+    find . -name CMakeLists.txt -print0 | xargs -0 perl -pi -e '/include\(GNUInstallDirs/ && ($_ .= q{
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE PATH "Library installation directory." FORCE)
 GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_LIBDIR CMAKE_INSTALL_LIBDIR)
-})' $(find . -name CMakeLists.txt)
+})'
 }
 
 codes_curl() {

--- a/installers/rpm-code/codes/openmc.sh
+++ b/installers/rpm-code/codes/openmc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 openmc_dagmc() {
-    codes_download svalinn/DAGMC develop
+    codes_download svalinn/DAGMC "$version"
     codes_cmake \
         -D BUILD_STATIC_LIBS=OFF \
         -D BUILD_TALLY=ON \
@@ -15,6 +15,7 @@ openmc_main() {
     codes_yum_dependencies eigen3-devel
     codes_dependencies common
     openmc_moab
+    version=develop
     openmc_dagmc
     openmc_openmc
 }
@@ -32,7 +33,7 @@ openmc_moab() {
 }
 
 openmc_openmc() {
-    codes_download openmc-dev/openmc develop
+    codes_download openmc-dev/openmc "$version"
     codes_cmake_fix_lib_dir
     CXX=mpicxx codes_cmake \
         -D CMAKE_INSTALL_PREFIX="${codes_dir[prefix]}" \
@@ -44,5 +45,5 @@ openmc_openmc() {
 }
 
 openmc_python_install() {
-    install_pip_install git+https://github.com/openmc-dev/openmc.git@develop
+    install_pip_install git+https://github.com/openmc-dev/openmc.git@"$version"
 }

--- a/installers/rpm-code/codes/openmc.sh
+++ b/installers/rpm-code/codes/openmc.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+openmc_dagmc() {
+    codes_download svalinn/DAGMC develop
+    codes_cmake \
+        -D BUILD_STATIC_LIBS=OFF \
+        -D BUILD_TALLY=ON \
+        -D CMAKE_INSTALL_PREFIX="${codes_dir[prefix]}" \
+        -D MOAB_DIR="${codes_dir[prefix]}"
+    codes_make
+    codes_make_install
+}
+
+openmc_main() {
+    codes_yum_dependencies eigen3-devel
+    codes_dependencies common
+    openmc_moab
+    openmc_dagmc
+    openmc_openmc
+}
+
+openmc_moab() {
+    codes_download https://bitbucket.org/fathomteam/moab.git Version5.1.0
+    codes_cmake_fix_lib_dir
+    codes_cmake \
+        -D CMAKE_INSTALL_PREFIX="${codes_dir[prefix]}" \
+        -D ENABLE_HDF5=ON \
+        -D HDF5_INCLUDE_DIR="${codes_dir[prefix]}" \
+        -D HDF5_ROOT="$BIVIO_MPI_LIB"
+    codes_make
+    codes_make_install
+}
+
+openmc_openmc() {
+    codes_download openmc-dev/openmc develop
+    codes_cmake_fix_lib_dir
+    CXX=mpicxx codes_cmake \
+        -D CMAKE_INSTALL_PREFIX="${codes_dir[prefix]}" \
+        -D HDF5_INCLUDE_DIRS="${codes_dir[prefix]}" \
+        -D HDF5_PREFER_PARALLEL=on \
+        -D OPENMC_USE_DAGMC=on
+    codes_make
+    codes_make_install
+}
+
+openmc_python_install() {
+    install_pip_install git+https://github.com/openmc-dev/openmc.git@develop
+}

--- a/installers/rpm-code/dev-build-all.sh
+++ b/installers/rpm-code/dev-build-all.sh
@@ -44,6 +44,7 @@ codes=(
 # see pyopaltools.sh
 #    pyopaltools
     opal
+    openmc
 
     # needs hypre and metis
     petsc


### PR DESCRIPTION
In addition, modify codes_cmake_fix_lib_dir to account for submodules
with their own makefiles. For example, openmc has [submodules](https://github.com/openmc-dev/openmc/tree/2f068863d032d56152505c7d8ff6b969f4705003/vendor) 
and they have [their own CMakeLists.txt](https://github.com/fmtlib/fmt/blob/d141cdbeb0fb422a3fb7173b285fd38e0d1772dc/CMakeLists.txt)