### PR TITLE
Fix radiasoft/sirepo#4343: make tqdm a common dep

### DIFF
--- a/installers/rpm-code/codes/common.sh
+++ b/installers/rpm-code/codes/common.sh
@@ -45,6 +45,8 @@ common_python() {
         prompt_toolkit
     # fortran namelist parser, usable by many codes
     install_pip_install f90nml
+    # Conflict between rscode-bluesky and rscode-openpmd
+    install_pip_install tqdm
     # Lots of dependencies so we install here to avoid rpm collisions.
     # Slows down builds of pykern, but doesn't affect development.
     codes_download pykern


### PR DESCRIPTION
Multiple packages depend on tqdm so move into common.