### PR TITLE
Fix #268 support ubuntu, and do not depend on vssh in downloaders

### DIFF
--- a/installers/slurm-dev/radiasoft-download.sh
+++ b/installers/slurm-dev/radiasoft-download.sh
@@ -12,7 +12,7 @@ slurm_dev_main() {
             install_err 'You need to run:
 
 radia_run vagrant-dev fedora
-vssh
+vagrant ssh
 radia_run slurm-dev
 '
         fi

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -21,10 +21,18 @@ vagrant_dev_box_add() {
         box=$vagrant_dev_box
     elif [[ $box =~ fedora ]]; then
         if [[ $box == fedora ]]; then
-            box=fedora/32-cloud-base
+            if [[ $_vagrant_dev_host_os == ubuntu ]]; then
+                box=generic/fedora32
+            else
+                box=fedora/32-cloud-base
+            fi
         fi
     elif [[ $box == centos ]]; then
-        box=centos/7
+        if [[ $_vagrant_dev_host_os == ubuntu ]]; then
+            box=generic/centos7
+        else
+            box=centos/7
+        fi
     fi
     if vagrant box list | grep "$box" >& /dev/null; then
         vagrant box update --box "$box"


### PR DESCRIPTION
Has not been tested on ubuntu, but ran on a mac fine.

- use vagrant ssh in downloaders, not vssh, because vssh is somewhat unreliable and depends on "single user" environments.
- ubuntu uses libvirt so take out vbguest. also persistent storage is different so don't use.