### PR TITLE
fix #285: remove GITHUB_EVENT_NAME check and rename installer

### DIFF
--- a/installers/python-ci/radiasoft-download.sh
+++ b/installers/python-ci/radiasoft-download.sh
@@ -2,10 +2,7 @@
 #
 # Assumes running in GITHUB
 #
-ci_pull_request_main() {
-    if [[ ${GITHUB_EVENT_NAME:-} != pull_request ]]; then
-        install_err "GITHUB_EVENT_NAME=${GITHUB_EVENT_NAME:-} not pull_request"
-    fi
+python_ci_main() {
     if [[ ! -r setup.py ]]; then
         install_err 'no setup.py'
     fi


### PR DESCRIPTION
also requires fixing workflow files in [radiasoft/sirepo](https://github.com/radiasoft/sirepo/) and [radiasoft/pykern](https://github.com/radiasoft/pykern)