### PR TITLE
Fix #364: sys no longer has attribute setcheckinterval

### DIFF
--- a/installers/rpm-code/codes/pyzgoubi.sh
+++ b/installers/rpm-code/codes/pyzgoubi.sh
@@ -9,4 +9,18 @@ pyzgoubi_python_install() {
 pyzgoubi_main() {
     codes_dependencies common
     codes_download https://github.com/PyZgoubi/PyZgoubi.git
+    pyzgoubi_patch
+}
+
+pyzgoubi_patch() {
+    patch zgoubi/core.py <<'EOF'
+@@ -67,7 +67,6 @@
+
+ zlog.setLevel(zgoubi_settings['log_level'])
+
+-sys.setcheckinterval(10000)
+
+ zgoubi_module_path = os.path.dirname(os.path.realpath(__file__))
+ # something like
+EOF
 }


### PR DESCRIPTION
In py3.2 and beyond this function didn't have any effect. In py3.9 it was removed. So I think it is safe to remove it here.