### PR TITLE
Fix #366: use latest shadow

### DIFF
--- a/installers/rpm-code/codes/shadow3.sh
+++ b/installers/rpm-code/codes/shadow3.sh
@@ -6,7 +6,7 @@ shadow3_main() {
 
 shadow3_python_install() {
     # devel-gfortran-yb66 on 20220603
-    install_pip_install srxraylib git+https://github.com/oasys-kit/shadow3.git@25f13e4ac742a96b3c18a95b6cc39e86403dae88
+    install_pip_install srxraylib shadow3
     install_pip_install --no-deps OASYS1-ShadowOui SYNED OASYS1-ShadowOui-Advanced-Tools
     local p=$(codes_python_lib_dir)/orangecontrib
     local u=$p/shadow/util


### PR DESCRIPTION
The error we are seeing is sometimes related to version incompatabilities between packages. So, update to the latest shadow3 which (may) work better with the other packages. At the very least the error goes away.