### PR TITLE
fix #371: install_repo_eval replaces install_repo everywhere

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -248,41 +248,6 @@ install_os_release_vars() {
     fi
 }
 
-install_repo() {
-    if (( $# > 0 )); then
-        install_repo=$1
-        shift
-        install_extra_args=( "$@" )
-        install_script_dir=
-    fi
-    declare first rest
-    if [[ ! ${install_repo:-/} =~ / ]]; then
-        if [[ $install_repo =~ \.sh$ ]]; then
-            install_url ''
-            install_script_eval "$install_repo"
-            return
-        fi
-        first=download
-        rest=installers/$install_repo
-    elif [[ $install_repo =~ ^/*([^/].*[^/])/*$ ]]; then
-        first=${BASH_REMATCH[1]}
-        if [[ $first =~ ^([^/]+/[^/]+)/(.+)$ ]]; then
-            first=${BASH_REMATCH[1]}
-            rest=${BASH_REMATCH[2]}
-        elif [[ $first =~ ^([^/]+/[^/]+)$ ]]; then
-            rest=
-        fi
-    fi
-    if [[ ! $first ]]; then
-        install_err "$install_repo: invalid repo name"
-    fi
-    if [[ ! $first =~ / ]]; then
-        first=radiasoft/$first
-    fi
-    install_url "$first" "$rest"
-    install_script_eval radiasoft-download.sh
-}
-
 install_repo_as_root() {
     install_repo_as_user root "$@"
 }
@@ -329,7 +294,7 @@ install_repo_eval() {
         install_server="$install_server" \
         install_depot_server="$install_depot_server" \
         install_url= \
-        install_repo "$@"
+        install_repo_internal "$@"
     cd "$prev_pwd"
 }
 
@@ -368,6 +333,41 @@ install_script_eval() {
     if [[ $m && $(type -t "$m") == function ]]; then
         $m ${install_extra_args[@]+"${install_extra_args[@]}"}
     fi
+}
+
+install_repo_internal() {
+    if (( $# > 0 )); then
+        install_repo=$1
+        shift
+        install_extra_args=( "$@" )
+        install_script_dir=
+    fi
+    declare first rest
+    if [[ ! ${install_repo:-/} =~ / ]]; then
+        if [[ $install_repo =~ \.sh$ ]]; then
+            install_url ''
+            install_script_eval "$install_repo"
+            return
+        fi
+        first=download
+        rest=installers/$install_repo
+    elif [[ $install_repo =~ ^/*([^/].*[^/])/*$ ]]; then
+        first=${BASH_REMATCH[1]}
+        if [[ $first =~ ^([^/]+/[^/]+)/(.+)$ ]]; then
+            first=${BASH_REMATCH[1]}
+            rest=${BASH_REMATCH[2]}
+        elif [[ $first =~ ^([^/]+/[^/]+)$ ]]; then
+            rest=
+        fi
+    fi
+    if [[ ! $first ]]; then
+        install_err "$install_repo: invalid repo name"
+    fi
+    if [[ ! $first =~ / ]]; then
+        first=radiasoft/$first
+    fi
+    install_url "$first" "$rest"
+    install_script_eval radiasoft-download.sh
 }
 
 install_source_bashrc() {

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -212,7 +212,7 @@ install_main() {
     install_msg "Log: $install_log_file"
     install_log install_main
     install_args "$@"
-    install_repo
+    install_repo_internal
     install_clean
     if [[ -z $install_verbose ]]; then
         rm -f "$install_log_file" >& /dev/null || true
@@ -246,6 +246,10 @@ install_os_release_vars() {
         # Have something legal; unlikely to get here
         export install_os_release_version_id=0
     fi
+}
+
+install_repo() {
+    install_err 'install_repo is deprecated, use install_repo_eval'
 }
 
 install_repo_as_root() {

--- a/installers/sirepo-ci-build/radiasoft-download.sh
+++ b/installers/sirepo-ci-build/radiasoft-download.sh
@@ -50,5 +50,5 @@ EOF
     gcl container-beamsim
     gcl container-sirepo-ci
     cd container-beamsim
-    build_docker_post_hook=$x install_repo container-build
+    build_docker_post_hook=$x install_repo_eval container-build
 }

--- a/installers/warp/radiasoft-download.sh
+++ b/installers/warp/radiasoft-download.sh
@@ -4,8 +4,8 @@
 #
 
 warp_main() {
-    if [[ -z $NERSC_HOST ]]; then
-        install_repo code warp
+    if [[ -z ${NERSC_HOST:-} ]]; then
+        install_repo_eval code warp
         return $?
     fi
     if [[ $NERSC_HOST != cori ]]; then


### PR DESCRIPTION
@robnagler I don't have permission to push to [radiasoft/container-python3](https://github.com/radiasoft/container-python3), but [install_repo should be replaced with install_repo_eval](https://github.com/radiasoft/container-python3/blob/20bd470e4a3d8eb6d08a0e60c9cf7143f52ebea7/container-conf/build.sh#L7) before this is merged.