### PR TITLE
Fix #381: add synergia back in for f32

### DIFF
--- a/installers/beamsim-codes/radiasoft-download.sh
+++ b/installers/beamsim-codes/radiasoft-download.sh
@@ -18,6 +18,7 @@ declare -a _beamsim_codes_all=(
     # create a delay here so radiasoft.repo in radiasoft/rpm-code
     # is "old" by the time bnlcrl (or other fast build) happens
     # otherwise, the cache will be stale
+    synergia
     jspec
 
     bnlcrl

--- a/installers/rpm-code/codes/ml.sh
+++ b/installers/rpm-code/codes/ml.sh
@@ -40,8 +40,7 @@ ml_python_install_f32() {
     )
     install_pip_install "${x[@]}"
     install_pip_install --no-deps tensorflow==2.3.1
-    install_pip_install keras==2.4.3 \
-        scikit-learn
+    install_pip_install keras==2.4.3 scikit-learn
 
 }
 
@@ -73,7 +72,6 @@ ml_python_install_f36() {
         'tensorflow_estimator>=2.10.0,<2.11'
         'termcolor>=1.1.0'
         'typing_extensions>=3.6.6'
-        'wrapt>=1.11.0'
     )
     install_pip_install "${x[@]}"
     install_pip_install --no-deps tensorflow==2.10.0

--- a/installers/rpm-code/codes/rsbeams.sh
+++ b/installers/rpm-code/codes/rsbeams.sh
@@ -6,6 +6,7 @@ _rsbeam_codes=(
     rslaser
     rsoopic
     rsopt
+    rssynergia
     rswarp
 )
 


### PR DESCRIPTION
Also, wrapt had been previously moved into common.sh (during f36 migration). But, when f32 ml.sh was brought back it made its way back in. It can live in common and both versions of tensorflow (f32 and f36) depend on the same version of wrapt so no conditional is needed.