### PR TITLE
Fix #398: Switch to python 3.9 in fedora 36

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -199,7 +199,7 @@ install_init_vars() {
     install_prog="curl $install_depot_server | bash -s"
     # These vars are only used in a few cases, e.g. vagrant-dev and pyenv
     : ${install_version_fedora:=36}
-    : ${install_version_python:=3.10.5}
+    : ${install_version_python:=3.9.15}
     : ${install_version_python_venv:=py${install_version_python%%.*}}
     : ${install_version_centos:=7}
     eval "$(install_vars_export)"


### PR DESCRIPTION
We tried upgrading to python 3.10 in the fedora 36 migration. But we ran into issues with it and srw
(https://github.com/radiasoft/sirepo/issues/5276).  Python 3.9 works and will be supported for some time so switching to it.