### PR TITLE
fix #402: declare on _rsbeams_codes causes unbound variable

### DIFF
--- a/installers/rpm-code/codes/rsbeams.sh
+++ b/installers/rpm-code/codes/rsbeams.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-declare -a _rsbeam_codes=(
+_rsbeam_codes=(
     rsbeams
     rsflash
     rslaser
@@ -12,7 +12,7 @@ declare -a _rsbeam_codes=(
 rsbeams_main() {
     rsbeams_init_vars
     codes_dependencies common ml
-    local r
+    declare r
     for r in "${_rsbeam_codes[@]}"; do
         codes_download radiasoft/"$r"
         cd ..
@@ -27,7 +27,7 @@ rsbeams_init_vars() {
 
 rsbeams_python_install() {
     install_pip_install nlopt DFO-LS Libensemble yt
-    local r
+    declare r
     for r in "${_rsbeam_codes[@]}"; do
         cd "$r"
         codes_python_install


### PR DESCRIPTION
This is some bit of bash that I don't understand, was unable to reproduce in a local script, and can't find an answer for online. @robnagler when _rsbeam_codes is defined with declare then the array is empty. Likewise calling `${#_rsbeam_codes[@]}` results in unbound variable. Removing the `declare` fixed the problem. Do you have any idea why that might be?