### PR TITLE
Fix radiasoft/sirepo#5582: use setswitchinterval instead of setcheckinterval

### DIFF
--- a/installers/flash-tarball/radiasoft-download.sh
+++ b/installers/flash-tarball/radiasoft-download.sh
@@ -5,7 +5,7 @@ _flash_tarball_version=4.6.2
 
 flash_tarball_main() {
     local d=$PWD/proprietary
-    local t=$d/FLASH-$_flash_tarball_version.tar.gz
+    local t=$d/FLASH$_flash_tarball_version.tar.gz
     if [[ ! -f $t ]]; then
             install_err "$t must exist"
     fi
@@ -14,7 +14,7 @@ flash_tarball_main() {
     local r=()
     install_url radiasoft/download installers
     install_script_eval rpm-code/codes.sh
-    codes_download rsflash
+    codes_download flashcap
     git fetch --unshallow
     local x
     for x in \
@@ -40,7 +40,6 @@ flash_tarball_main() {
 
 flash_tarball_patch_and_update_tgz() {
     local src_tgz=$1
-    # missing the dash
     local b=FLASH$_flash_tarball_version
     tar xzf "$src_tgz"
     cd "$b"
@@ -61,6 +60,33 @@ flash_tarball_patch_and_update_tgz() {
 < F90FLAGS =
 ---
 > F90FLAGS = -fallow-argument-mismatch
+EOF
+
+    # The following patches both contain trailing whitespace because
+    # the original source file contains it. Keeping the trailing
+    # whitespace makes the patch smaller which makes the important
+    # change in the patch easier to see.
+    patch --quiet bin/setup.py <<'EOF'
+@@ -13,7 +13,7 @@
+ 
+ ########################### START SCRIPT ################################
+ def main():
+-    sys.setcheckinterval(10000) # this is not threaded application
++    sys.setswitchinterval(10000) # this is not threaded application
+ 
+     parseCmd.init()
+     # setup.py is FLASH_HOME/bin/setup.py
+EOF
+    patch --quiet tools/python/flmake/setup.py <<'EOF'
+@@ -32,7 +32,7 @@
+     global RUNTIME_FILES
+ 
+     # this is not a threaded application
+-    sys.setcheckinterval(10000)
++    sys.setswitchinterval(10000)
+     cwdir = os.getcwd()
+ 
+     # setup.py is FLASH_HOME/bin/setup.py
 EOF
     cd ..
     mv "$b" "flash"


### PR DESCRIPTION
setcheckinterval was deprecated in python 3.2 and removed in pyton 3.9