### PR TITLE
Fix #492 OPAL 2022.1.0 and trilinos 13.0.1

### DIFF
--- a/installers/rpm-code/codes/opal.sh
+++ b/installers/rpm-code/codes/opal.sh
@@ -3,7 +3,7 @@ opal_main() {
     # NOTE: trilinos is not added as an rpm dependency see ../radiasoft-download.sh
     codes_dependencies trilinos h5hut boost
     opal_mithra
-    codes_download https://gitlab.psi.ch/OPAL/src/-/archive/OPAL-2021.1.0/src-OPAL-2021.1.0.tar.bz2
+    codes_download https://gitlab.psi.ch/OPAL/src/-/archive/OPAL-2022.1.0/src-OPAL-2022.1.0.tar.bz2
     # git.radiasoft.org/download/issues/342
     perl -pi -e 's{add_compile_options \(-Werror\)}{}' CMakeLists.txt
     perl -pi -e '

--- a/installers/rpm-code/codes/trilinos.sh
+++ b/installers/rpm-code/codes/trilinos.sh
@@ -2,8 +2,7 @@
 
 trilinos_main() {
     codes_dependencies metis
-    # codes_download https://github.com/trilinos/Trilinos/archive/trilinos-release-13-0-1.tar.gz Trilinos-trilinos-release-13-0-1 trilinos 13.0.1
-    codes_download https://github.com/trilinos/Trilinos/archive/trilinos-release-12-10-1.tar.gz Trilinos-trilinos-release-12-10-1 trilinos 12.10.1
+    codes_download https://github.com/trilinos/Trilinos/archive/trilinos-release-13-0-1.tar.gz Trilinos-trilinos-release-13-0-1 trilinos 13.0.1
     local x=(
         -D CMAKE_CXX_FLAGS:STRING="-DMPICH_IGNORE_CXX_SEEK -fPIC"
         -D CMAKE_CXX_STANDARD:STRING="11"


### PR DESCRIPTION
Once merged, this should be built on alpha. 