### PR TITLE
Fix radiasoft/sirepo#6100: pin numpy to version without min/max names

### DIFF
--- a/installers/rpm-code/codes/common.sh
+++ b/installers/rpm-code/codes/common.sh
@@ -35,7 +35,10 @@ common_python() {
     codes_dir[pyenv_prefix]=$(realpath "$(pyenv prefix)")
     declare -a d=(
         mpi4py
-        numpy
+        # numpy 1.25 adds words like min and max to the global namespace which
+        # then overrides the python builtins.
+        # https://git.radiasoft.org/sirepo/issues/6100
+        'numpy<1.25'
         # required by cmyt 1.3.0 (required by yt)
         # https://github.com/radiasoft/download/issues/497
         'matplotlib>=3.5.0'


### PR DESCRIPTION
In numpy version 1.25 there are now function min and max on the numpy object. So, `from numpy import *` overrides the python builtin min and max names.

This breaks at least warp and gist. Maybe other packages.