### PR TITLE
Fix #510: remove numpy pin

### DIFF
--- a/installers/rpm-code/codes/common.sh
+++ b/installers/rpm-code/codes/common.sh
@@ -35,10 +35,7 @@ common_python() {
     codes_dir[pyenv_prefix]=$(realpath "$(pyenv prefix)")
     declare -a d=(
         mpi4py
-        # numpy 1.25 adds words like min and max to the global namespace which
-        # then overrides the python builtins.
-        # https://git.radiasoft.org/sirepo/issues/6100
-        'numpy<1.25'
+        numpy
         # required by cmyt 1.3.0 (required by yt)
         # https://github.com/radiasoft/download/issues/497
         'matplotlib>=3.5.0'


### PR DESCRIPTION
In https://github.com/numpy/numpy/releases/tag/v1.25.2 numpy fixed the issuse that causes `from numpy import *` to override builtins like min and max.

They've promised to keep this behavior until numpy 2.0 when `from numpy import *` will once again override the builtins. I chose not to put a pin to <2.0 so we know when 2.0 is released and we can test against it. If 2.0 proves to be too big of a change we can pin then.