### PR TITLE
Fix #513: Fix warp (numpy and math)

### DIFF
--- a/installers/rpm-code/codes/pymesh.sh
+++ b/installers/rpm-code/codes/pymesh.sh
@@ -3,6 +3,7 @@
 pymesh_python_install() {
     cd PyMesh
     perl -pi -e 's{.*third_party.*(cgal|eigen|tetgen|clipper|qhull|cork|carve|draco|mmg|tbb|json).*}{}' setup.py
+    pymesh_patch_numpy_testing
     NUM_CORES=$(codes_num_cores) codes_python_install
 }
 
@@ -36,4 +37,21 @@ pymesh_main() {
     #    git submodule update --init --recursive third_party/fmt
     # cgal is very large so use --depth=5 fmt needs --depth=10
     #    git submodule update --init --depth=5 $(find third_party/* -maxdepth 0 -type d | egrep -iv '(geogram|fmt|mmg|cgal)')
+}
+
+pymesh_patch_numpy_testing() {
+    # numpy.testing.Tester is an alias for NoseTester. It was removed in numpy 1.25. Furthermore,
+    # nose doesn't work with python 3. Removing has no impact on pymesh. Tests aren't run.
+    patch --quiet python/pymesh/__init__.py<<'EOF'
+@@ -2,9 +2,6 @@
+ from . import PyMeshSetting
+ from .timethis import timethis
+
+-from numpy.testing import Tester
+-test = Tester().test
+-
+ # Set default logging handler to avoid "No handler found" warnings.
+ import logging
+ try:  # Python 2.7+
+EOF
 }

--- a/installers/rpm-code/codes/warp.sh
+++ b/installers/rpm-code/codes/warp.sh
@@ -4,6 +4,7 @@ warp_python_install() {
     cd warp
     warp_py_2_to_3
     warp_patch_numpy
+    warp_patch_math
     cd pywarp90
     warp_patch_makefiles
     warp_patch_serial_setup_py
@@ -118,6 +119,19 @@ EOF
  clean:
  	rm -rf $(BUILDBASEDIR) *.o ../scripts/$(BUILDBASEDIR) ../scripts/__version__.py
 -
+EOF
+}
+
+warp_patch_math() {
+    patch --quiet scripts/field_solvers/em3dsolver.py<<'EOF'
+@@ -5,6 +5,7 @@
+ import collections
+ import types
+ import operator
++import math
+
+ try:
+     import Opyndx
 EOF
 }
 


### PR DESCRIPTION
Two changes:
1. rswarp depends on pymesh. pymesh depends on numpy.testing.Tester. This is an alias for NoseTester and was removed in numpy 1.25. We don't need to import it becaue we don't run the warp tests
2. Warp used python's math module but didn't import it.