### PR TITLE
WIP radiasoft/container-sirepo-devbox#7: Move common sirepo container…

### DIFF
--- a/installers/container-sirepo-base/radiasoft-download.sh
+++ b/installers/container-sirepo-base/radiasoft-download.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
 container_sirepo_base_main() {
-    declare user=${1:-}
-    if [[ $user == root ]]; then
-        container_sirepo_base_root
-        return
-    fi
-    container_sirepo_base_run_user
+    declare user=$1
+    case $user in
+        "root")
+            container_sirepo_base_root
+            ;;
+        "run_user")
+            container_sirepo_base_run_user
+            ;;
+        *)
+            install_err
+            exit "user=$1 unknown. Please set 'root' or 'run_user'"
+            ;;
+    esac
 }
 
 container_sirepo_base_root() {

--- a/installers/container-sirepo-base/radiasoft-download.sh
+++ b/installers/container-sirepo-base/radiasoft-download.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
+#
+# Install dependencies common to containers for Sirepo development and CI.
+#
 
 container_sirepo_base_main() {
     declare user=$1
     case $user in
-        "root")
+        root)
             container_sirepo_base_root
             ;;
-        "run_user")
+        run_user)
             container_sirepo_base_run_user
             ;;
         *)
-            install_err
-            exit "user=$1 unknown. Please set 'root' or 'run_user'"
+            install_err "user=$1 unknown. Please set 'root' or 'run_user'"
             ;;
     esac
 }

--- a/installers/container-sirepo-base/radiasoft-download.sh
+++ b/installers/container-sirepo-base/radiasoft-download.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+container_sirepo_base_main() {
+    declare user=${1:-}
+    if [[ $user == root ]]; then
+        container_sirepo_base_root
+        return
+    fi
+    container_sirepo_base_run_user
+}
+
+container_sirepo_base_root() {
+    build_yum install fedora-workstation-repositories
+    build_yum config-manager --set-enabled google-chrome
+    build_yum install google-chrome-stable
+}
+
+container_sirepo_base_run_user() {
+    install_url radiasoft/sirepo
+    #POSIT: This relies on the fact that individual package names don't have spaces or special chars
+    npm install -g \
+        $(install_download package.json | jq -r '.devDependencies | to_entries | map("\(.key)@\(.value)") | .[]')
+}


### PR DESCRIPTION
… functionality into installer

Both container-sirepo-ci and container-sirepo-devbox require some common functionality but they are based on different base images. So, move the common bits into an installer that can be called from both.