### PR TITLE
Fix #519 patch mpicxx & mpi.h and remove mpicxx.h

### DIFF
--- a/installers/fedora-patches/radiasoft-download.sh
+++ b/installers/fedora-patches/radiasoft-download.sh
@@ -9,6 +9,7 @@ fedora_patches_mpich() {
     # to read the recorded switches:
     # readelf -p .GCC.command.line a.out
 
+    # -lmpicxx is deprecated so don't link with it
     install_sudo perl -pi -w -e '
     s{-Wp,-D_FORTIFY_SOURCE=2}{}g;
     s{-Wp,-D_GLIBCXX_ASSERTIONS}{}g;
@@ -22,7 +23,13 @@ fedora_patches_mpich() {
     # these flags are supplied by make/cmake
     s{-O2}{}g;
     s{-g\b}{}g;
+    s{"-lmpicxx"}{ # patched by git.radiasoft.org/download};
     ' /usr/lib64/mpich/bin/mpifort /usr/lib64/mpich/bin/mpic{c,xx}
+    install_sudo perl -pi -w -e '
+    s{#include "mpicxx.h"}{/* patched by git.radiasoft.org/download */};
+    ' /usr/include/mpich-x86_64/mpi.h
+    # Ensure compile time failures for mpi c++ bindings
+    install_sudo rm -f /usr/include/mpich-x86_64/mpicxx.h
     if grep -s -q format-security /usr/lib64/mpich/bin/mpifort; then
         # mpif77 and mpif90 are symlinks
         install_sudo perl -pi -w -e 's{-Werror=format-security}{}g' /usr/lib64/mpich/bin/mpifort

--- a/installers/rpm-code/codes/openmc.sh
+++ b/installers/rpm-code/codes/openmc.sh
@@ -2,7 +2,7 @@
 
 openmc_dagmc() {
     local p="$PWD"
-    codes_download svalinn/DAGMC "$version"
+    codes_download svalinn/DAGMC develop
     codes_cmake \
         -D BUILD_STATIC_LIBS=OFF \
         -D BUILD_TALLY=ON \
@@ -17,14 +17,14 @@ openmc_main() {
     codes_yum_dependencies eigen3-devel
     codes_dependencies common
     openmc_moab
-    version=develop
     openmc_dagmc
     openmc_openmc
 }
 
 openmc_moab() {
     local p="$PWD"
-    codes_download https://bitbucket.org/fathomteam/moab.git Version5.1.0
+    # 20230827 fixes pymoab/core.pyx:1509:48: no suitable method found
+    codes_download https://bitbucket.org/fathomteam/moab.git bfccfc78e6cb3ddc02c39be437a64696bf126d86
     codes_cmake_fix_lib_dir
     # This cmake module uses python-config which doesn't work with venv
     # https://mail.python.org/archives/list/python-ideas@python.org/thread/QTCPOM5YBOKCWWNPDP7Z4QL2K6OWGSHL/
@@ -44,11 +44,10 @@ openmc_moab() {
 }
 
 openmc_openmc() {
-    codes_download openmc-dev/openmc "$version"
+    codes_download openmc-dev/openmc develop
     codes_cmake_fix_lib_dir
     CXX=mpicxx codes_cmake \
         -D CMAKE_INSTALL_PREFIX="${codes_dir[prefix]}" \
-        -D ENABLE_PYMOAB=ON \
         -D HDF5_PREFER_PARALLEL=on \
         -D OPENMC_USE_DAGMC=on \
         -D OPENMC_USE_MPI=on


### PR DESCRIPTION
- Remove references to C++ bindings
- Leave libmpicxx.so for already compiled code
- openmc/moab: Fix 'no suitable method found' in compile
  `pymoab/core.pyx:1509:48: no suitable method found`
   Numpy change "unsigned long is not np.uint64_t"
