### PR TITLE
Fix #524: Add openssh-server to redhat-base

### DIFF
--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -77,6 +77,7 @@ EOF
         make
         moreutils
         nginx
+        openssh-server
         openssl
         openssl-devel
         patch


### PR DESCRIPTION
We use openssh-server in multiple higher-level images so add it here and remove specifying in each higher image individually.