### PR TITLE
add --no-cache-dir to pip install to free space during ci run

### DIFF
--- a/installers/python-ci/radiasoft-download.sh
+++ b/installers/python-ci/radiasoft-download.sh
@@ -50,7 +50,7 @@ python_ci_main() {
                 pip install git+https://'${GITHUB_TOKEN:+$GITHUB_TOKEN@}'github.com/radiasoft/\$x.git
             done
             pip uninstall -y '$r' >& /dev/null || true
-            pip install -e .
+            pip install --no-cache-dir -e .
             export PYKERN_PKCLI_TEST_MAX_FAILURES=1 PYKERN_PKCLI_TEST_RESTARTABLE=1
             if [[ -f test.sh ]]; then
                 bash test.sh

--- a/installers/python-ci/radiasoft-download.sh
+++ b/installers/python-ci/radiasoft-download.sh
@@ -50,6 +50,8 @@ python_ci_main() {
                 pip install git+https://'${GITHUB_TOKEN:+$GITHUB_TOKEN@}'github.com/radiasoft/\$x.git
             done
             pip uninstall -y '$r' >& /dev/null || true
+            # GitHub CI runners are limited on disk space so use --no-cache-dir to limit disk usage as much as
+            # possible. See git.radiasoft.org/downloads/issues/XXX
             pip install --no-cache-dir -e .
             export PYKERN_PKCLI_TEST_MAX_FAILURES=1 PYKERN_PKCLI_TEST_RESTARTABLE=1
             if [[ -f test.sh ]]; then

--- a/installers/python-ci/radiasoft-download.sh
+++ b/installers/python-ci/radiasoft-download.sh
@@ -51,7 +51,7 @@ python_ci_main() {
             done
             pip uninstall -y '$r' >& /dev/null || true
             # GitHub CI runners are limited on disk space so use --no-cache-dir to limit disk usage as much as
-            # possible. See git.radiasoft.org/downloads/issues/XXX
+            # possible. See git.radiasoft.org/downloads/issues/562
             pip install --no-cache-dir -e .
             export PYKERN_PKCLI_TEST_MAX_FAILURES=1 PYKERN_PKCLI_TEST_RESTARTABLE=1
             if [[ -f test.sh ]]; then


### PR DESCRIPTION
fix https://github.com/radiasoft/download/issues/562
I would like to try adding `--no-cache-dir` to see if it will fix the OSError that we are running into in a private repo.
Here is pip's documentation on the potential downsides of adding this flag. https://pip.pypa.io/en/stable/topics/caching/#disabling-caching