### PR TITLE
Fix #590: update tensorflow to 2.15.0

### DIFF
--- a/installers/beamsim-codes/radiasoft-download.sh
+++ b/installers/beamsim-codes/radiasoft-download.sh
@@ -66,7 +66,6 @@ declare -a _beamsim_codes_all=(
 
     warpx
 
-    xraylib
     shadow3
 
     pyzgoubi
@@ -90,7 +89,6 @@ declare -a _beamsim_codes_install_skip=(
     forthon
     openpmd
     pygist
-    xraylib
     pyzgoubi
 )
 

--- a/installers/rpm-code/codes/bluesky.sh
+++ b/installers/rpm-code/codes/bluesky.sh
@@ -2,7 +2,7 @@
 
 bluesky_main() {
     codes_yum_dependencies mesa-libGL mongodb-org-server
-    codes_dependencies common ipykernel shadow3 srw xraylib
+    codes_dependencies common ipykernel shadow3 srw
     bluesky_mongo
     if install_version_fedora_lt_36; then
         install_pip_install git+https://github.com/NSLS-II/sirepo-bluesky.git@e8043a3a182e250fa1f429882bf2728f46d1ec3a

--- a/installers/rpm-code/codes/common.sh
+++ b/installers/rpm-code/codes/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-common_install_mpi4py_h5py() {
+common_install_h5py() {
     # hdf5, h5py, and  tensorflow all need to agree with each other.
     # We install hdf5 with whatever the latest version from the fedora repos is.
     # We then must backtrack to see what h5py version supports that. They'll mention it in their
@@ -9,20 +9,14 @@ common_install_mpi4py_h5py() {
     # will list the h5py versions that tensorflow supports
 
     declare p="$PWD"
-    declare v=2.10.0
-    declare l="h5py==$v"
-    if ! install_version_fedora_lt_36; then
-        v=3.7.0
-        l='.'
-        # https://git.radiasoft.org/download/issues/422
-        codes_download h5py/h5py  3507819de54b35af05b2ca8ca55ec7e7b60cb919
-    fi
+    # https://git.radiasoft.org/download/issues/422
+    codes_download h5py/h5py 3.10.0
     declare mpicc=$(type -p mpicc)
     if [[ ! $mpicc ]]; then
         install_err mpicc not found
     fi
     # Force MPI mode (not auto-detected)
-    CC=$mpicc HDF5_MPI=ON install_pip_install --no-binary=h5py "$l"
+    CC=$mpicc HDF5_MPI=ON install_pip_install --no-binary=h5py .
     cd "$p"
 }
 
@@ -43,7 +37,7 @@ common_python() {
         Cython
     )
     install_pip_install "${d[@]}"
-    common_install_mpi4py_h5py
+    common_install_h5py
     d=(
         # Needed by omega
         openpmd-beamphysics
@@ -62,6 +56,7 @@ common_python() {
 
         # Needed by rscode-bluesky and rscode-ml
         cachetools
+        lxml
         scikit-image==0.18.3
         tifffile
         typing-extensions
@@ -98,6 +93,9 @@ common_python() {
         jsonschema
         tenacity
         tzlocal
+
+        # conflict between rscode-bluesky and rscode-shadow3
+        xraylib
 
         # conflict between rscode-openmc and rscode-ml
         protobuf

--- a/installers/rpm-code/codes/ml.sh
+++ b/installers/rpm-code/codes/ml.sh
@@ -7,74 +7,36 @@ ml_main() {
 
 ml_python_install() {
     install_pip_install h5ImageGenerator
-    if install_version_fedora_lt_36; then
-        ml_python_install_f32
-        return
-    fi
-    ml_python_install_f36
-}
-
-ml_python_install_f32() {
-    declare x=(
-        'absl-py>=0.7.0'
-        'gast==0.3.3'
-        'google-pasta>=0.1.8'
-        'grpcio>=1.8.6'
-        'keras-preprocessing<1.2,>=1.1.1'
-        'opt-einsum>=2.3.2'
-        'protobuf>=3.9.2'
-        'tensorboard<3,>=2.3.0'
-        'google-auth<2,>=1.6.3'
-        'cachetools<5.0,>=2.0.0'
-        'google-auth-oauthlib<0.5,>=0.4.1'
-        'markdown>=2.6.8'
-        'pyasn1-modules>=0.2.1'
-        'pyasn1<0.5.0,>=0.4.6'
-        'requests-oauthlib>=0.7.0'
-        'oauthlib>=3.0.0'
-        'rsa<5,>=3.1.4'
-        'tensorboard-plugin-wit>=1.6.0'
-        'tensorflow-estimator<2.4.0,>=2.3.0'
-        'termcolor>=1.1.0'
-        'werkzeug>=0.11.15'
-    )
-    install_pip_install "${x[@]}"
-    install_pip_install --no-deps tensorflow==2.3.1
-    install_pip_install keras==2.4.3 scikit-learn
-
-}
-
-
-ml_python_install_f36() {
-    # sympy is needed for webcon and rsbeams
-    # scikit-image is need for srw
-
+    # The tensorflow version we install must be supported by the CUDA version we have installed
+    # https://www.tensorflow.org/install/source#gpu
     # deps copied from tensorflow/tools/pip_package/setup.py
     local x=(
-        'absl-py>=1.0.0'
-        'astunparse>=1.6.0'
-        'flatbuffers>=2.0'
-        'gast>=0.2.1,<=0.4.0'
-        'google_pasta>=0.1.1'
-        'grpcio>=1.24.3,<2.0' # sys.byteorder == 'little' on our systems
-        'h5py>=2.9.0'
-        'keras>=2.10.0,<2.11'
-        'keras_preprocessing>=1.1.1'
-        'libclang>=13.0.0'
-        'numpy>=1.20'
-        'opt_einsum>=2.3.2'
-        'packaging'
-        'protobuf>=3.9.2,<3.20'
-        'setuptools'
-        'six>=1.12.0'
-        'tensorboard>=2.10,<2.11'
-        'tensorflow-io-gcs-filesystem>=0.23.1'
-        'tensorflow_estimator>=2.10.0,<2.11'
-        'termcolor>=1.1.0'
-        'typing_extensions>=3.6.6'
+    'absl-py>=1.0.0'
+    'astunparse>=1.6.0'
+    'flatbuffers>=23.5.26'
+    'gast>=0.2.1,!=0.5.0,!=0.5.1,!=0.5.2'
+    'google_pasta>=0.1.1'
+    'h5py>=2.9.0'
+    'libclang>=13.0.0'
+    'ml_dtypes~=0.2.0'
+    'numpy>=1.23.5,<2.0.0'
+    'opt_einsum>=2.3.2'
+    'packaging'
+    'protobuf>=3.20.3,<5.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    'setuptools'
+    'six>=1.12.0'
+    'termcolor>=1.1.0'
+    'typing_extensions>=3.6.6'
+    'wrapt>=1.11.0,<1.15'
+    'tensorflow-io-gcs-filesystem>=0.23.1'
+    'grpcio>=1.24.3,<2.0' # sys.byteorder == 'little' on our systems
+    'tensorboard>=2.15,<2.16'
+    'tensorflow_estimator>=2.15.0,<2.16'
+    'keras>=2.15.0,<2.16'
     )
     install_pip_install "${x[@]}"
-    install_pip_install --no-deps tensorflow==2.10.0
-    install_pip_install scikit-learn
-
+    install_pip_install --no-deps tensorflow==2.15.0
+    # scikit is need for srw
+    # sympy is needed for webcon and rsbeams
+    install_pip_install scikit-learn sympy
 }

--- a/installers/rpm-code/codes/shadow3.sh
+++ b/installers/rpm-code/codes/shadow3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 shadow3_main() {
-    codes_dependencies xraylib
+    codes_dependencies common
 }
 
 shadow3_python_install() {

--- a/installers/rpm-code/codes/xraylib.sh
+++ b/installers/rpm-code/codes/xraylib.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-xraylib_main() {
-    codes_dependencies common
-}
-
-xraylib_python_install() {
-    install_pip_install xraylib
-}


### PR DESCRIPTION
- update tensorflow to 2.15.0
- xraylib from rscode-xraylib conflicted with rscode-bluesky so it was moved into common. After this move there was nothing left in xraylib.sh so it was removed
- Removed some feature tests for f36 vs f32. There are tests in other places but I removed ones directly related to my work. We are going to be fully on f36 so all tests can be removed.
- update h5py to 3.10.0. This wasn't strictly necessary. Tensorflow can use and older h5py but since I was in here updating tensorflow I figured it was good to update related packages.