### PR TITLE
Fix #594: create installer for beamsim jupyter scientific packages

### DIFF
--- a/installers/beamsim-jupyter/radiasoft-download.sh
+++ b/installers/beamsim-jupyter/radiasoft-download.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Install dependencies common to beamsim-jupyter and container-jupyter-nvidia but
+# install the correct version for gpu vs not.
+#
+
+beamsim_jupyter_main() {
+    declare want_gpu=${1:-}
+    beamsim_jupyter_common
+    if [[ $want_gpu ]]; then
+        beamsim_jupyter_want_gpu
+    else
+        beamsim_jupyter_no_gpu
+    fi
+}
+
+beamsim_jupyter_common() {
+    llvmlite
+    numba
+
+    # needs to be before fbpic https://github.com/radiasoft/devops/issues/153
+    pyfftw
+    # https://github.com/radiasoft/devops/issues/152
+    fbpic
+
+# temporarily disable https://github.com/radiasoft/container-beamsim-jupyter/issues/40
+#        # https://github.com/radiasoft/jupyter.radiasoft.org/issues/75
+#        gpflow
+    # https://github.com/radiasoft/container-beamsim-jupyter/issues/10
+    GPy
+    # https://github.com/radiasoft/container-beamsim-jupyter/issues/11
+    safeopt
+    # https://github.com/radiasoft/container-beamsim-jupyter/issues/13
+    seaborn
+    # https://github.com/radiasoft/container-beamsim-jupyter/issues/38
+    # https://github.com/radiasoft/container-beamsim-jupyter/issues/39
+    botorch
+    # needed by zgoubidoo
+    parse
+
+    # https://github.com/radiasoft/container-beamsim-jupyter/issues/32
+    # installs bokeh, too
+    git+https://github.com/slaclab/lume-genesis
+    git+https://github.com/ChristopherMayes/openPMD-beamphysics
+    git+https://github.com/radiasoft/zfel
+
+    # https://github.com/radiasoft/container-beamsim-jupyter/issues/42
+    bluesky
+}
+
+# We need to pin versions because package versions need to be kept in
+# sync with gpu software versions (cuda).
+beamsim_jupyter_want_gpu() {
+    install_pip_install --index-url https://download.pytorch.org/whl/cu121 \
+        torch==2.1.2 \
+        torchaudio==2.1.2 \
+        torchvision==0.16.2
+    pip uninstall -y tensorflow
+    install_pip_install tensorflow[and-cuda]==2.15.0
+}
+
+# Match gpu versions to make it easy to move between environments.
+beamsim_jupyter_no_gpu() {
+    install_pip_install --index-url https://download.pytorch.org/whl/cpu \
+        torch==2.1.2 \
+        torchaudio==2.1.2 \
+        torchvision==0.16.2
+}

--- a/installers/rpm-code/codes/ml.sh
+++ b/installers/rpm-code/codes/ml.sh
@@ -6,37 +6,7 @@ ml_main() {
 }
 
 ml_python_install() {
-    install_pip_install h5ImageGenerator
-    # The tensorflow version we install must be supported by the CUDA version we have installed
-    # https://www.tensorflow.org/install/source#gpu
-    # deps copied from tensorflow/tools/pip_package/setup.py
-    local x=(
-    'absl-py>=1.0.0'
-    'astunparse>=1.6.0'
-    'flatbuffers>=23.5.26'
-    'gast>=0.2.1,!=0.5.0,!=0.5.1,!=0.5.2'
-    'google_pasta>=0.1.1'
-    'h5py>=2.9.0'
-    'libclang>=13.0.0'
-    'ml_dtypes~=0.2.0'
-    'numpy>=1.23.5,<2.0.0'
-    'opt_einsum>=2.3.2'
-    'packaging'
-    'protobuf>=3.20.3,<5.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
-    'setuptools'
-    'six>=1.12.0'
-    'termcolor>=1.1.0'
-    'typing_extensions>=3.6.6'
-    'wrapt>=1.11.0,<1.15'
-    'tensorflow-io-gcs-filesystem>=0.23.1'
-    'grpcio>=1.24.3,<2.0' # sys.byteorder == 'little' on our systems
-    'tensorboard>=2.15,<2.16'
-    'tensorflow_estimator>=2.15.0,<2.16'
-    'keras>=2.15.0,<2.16'
-    )
-    install_pip_install "${x[@]}"
-    install_pip_install --no-deps tensorflow==2.15.0
-    # scikit is need for srw
-    # sympy is needed for webcon and rsbeams
-    install_pip_install scikit-learn sympy
+    install_pip_install h5ImageGenerator \
+        scikit-learn sympy \
+        tensorflow==2.15.0
 }


### PR DESCRIPTION
Dependencies like jupyterhub are still installed in container-beamsim-jupyter/container-conf/buid.sh. But, all scientific packages (ex tensorflow) are now installed here.

This makes it easy to see everything in one place and make decisisions to handle gpu vs cpu.

In addition, tensorflow was updated. We now just install tensorflow and have pip handle the dependencies. The previous behavior of installing dependencies ourselves was to get around a bug we now hope is resolved.