### PR TITLE
Fix #600: Move dev-setup.sh into dev-env.sh

### DIFF
--- a/installers/rpm-code/dev-env.sh
+++ b/installers/rpm-code/dev-env.sh
@@ -26,3 +26,7 @@ export install_proprietary_key=proprietary_code
 # for convenience to test rpm-perl, not used here
 export rpm_perl_install_dir=$(_root)/radiasoft/rsconf/rpm
 unset _root
+if [[ ! -e $radiasoft_repo_file ]]; then
+    echo 'setting up one time'
+    bash dev-setup.sh
+fi

--- a/installers/rpm-code/dev-server.sh
+++ b/installers/rpm-code/dev-server.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 source ./dev-env.sh
-if [[ ! -e $radiasoft_repo_file ]]; then
-    echo 'setting up one time'
-    bash dev-setup.sh
-fi
 cd ~/src
 PYENV_VERSION=py3 exec pyenv exec python -m http.server "$dev_port"


### PR DESCRIPTION
dev-env.sh is called in more places (ex dev-server.sh and dev-build.sh) so we have a better chance of making sure the system will be properly setup regardless of what the developer is doing.