### PR TITLE
Fix #509: pin numpy < 2.0

### DIFF
--- a/installers/rpm-code/codes/common.sh
+++ b/installers/rpm-code/codes/common.sh
@@ -29,7 +29,8 @@ common_python() {
     codes_dir[pyenv_prefix]=$(realpath "$(pyenv prefix)")
     declare -a d=(
         mpi4py
-        numpy
+        # https://github.com/radiasoft/download/issues/509
+        'numpy<2.0.0'
         # required by cmyt 1.3.0 (required by yt)
         # https://github.com/radiasoft/download/issues/497
         'matplotlib>=3.5.0'


### PR DESCRIPTION
2.0 is a "break the world" (their words) release for numpy. We don't have a need to upgrade at the moment. So, stay on 1.x and let all dependent packages catch up to 2.0 before we update.