### PR TITLE
Fix #627: pin numpy 1.23.5

### DIFF
--- a/installers/rpm-code/codes/common.sh
+++ b/installers/rpm-code/codes/common.sh
@@ -29,8 +29,8 @@ common_python() {
     codes_dir[pyenv_prefix]=$(realpath "$(pyenv prefix)")
     declare -a d=(
         mpi4py
-        # https://github.com/radiasoft/download/issues/509
-        'numpy<2.0.0'
+        # https://github.com/radiasoft/download/issues/627
+        'numpy==1.23.5'
         # required by cmyt 1.3.0 (required by yt)
         # https://github.com/radiasoft/download/issues/497
         'matplotlib>=3.5.0'


### PR DESCRIPTION
numpy 1.24 removed numpy.float in favor of python float. This breaks many of the deps we use. So, stick with 1.23 series. 1.23.5 is the last release in the series and tensorflow expects at least it.