### PR TITLE
Fix #658 right pad shorter python version numbers

### DIFF
--- a/installers/nersc-sirepo-update/radiasoft-download.sh
+++ b/installers/nersc-sirepo-update/radiasoft-download.sh
@@ -73,8 +73,13 @@ nersc_sirepo_update_python_repos() {
     declare p t
     for p in pykern sirepo; do
         t=$(nersc_sirepo_update_shifter run "$image" python -c "import $p; print($p.__version__)")
-        if [[ ! $t =~ ^[0-9]{8}\.[0-9]{6}$ ]]; then
+        if [[ ! $t =~ ^[0-9]{8}\.[0-9]{1,6}$ ]]; then
             install_err "package=$p missing version: output=$t"
+        fi
+        # Right pad with zeros only if less than 15 chars to avoid
+        # precision issues in 64 bit floats.
+        if (( ${#t} < 15 )); then
+            t=$(printf '%0.6f' "$t")
         fi
         if [[ -d "$p" ]]; then
             cd "$p"


### PR DESCRIPTION
importlib.metadata.version removes trailing zeros so won't compare with version tag, which is always 15 chars.