### PR TITLE
Fix #666 add deps needed rsconf development

### DIFF
--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -57,6 +57,7 @@ EOF
         biosdevname
         bzip2
         bzip2-devel
+        createrepo
         emacs-nox
         gcc
         gcc-c++
@@ -77,6 +78,7 @@ EOF
         make
         moreutils
         nginx
+        opendkim
         openssh-server
         openssl
         openssl-devel


### PR DESCRIPTION
Don't like this solution, but the packages are small. They are needed on the rsconf server and for development so no common place for both.