### PR TITLE
Update AMReX, Add pyAMReX, ImpactX Py

### DIFF
--- a/installers/rpm-code/codes/amrex.sh
+++ b/installers/rpm-code/codes/amrex.sh
@@ -4,12 +4,13 @@ amrex_main() {
     codes_dependencies common
     codes_download https://github.com/AMReX-Codes/amrex/releases/download/24.05/amrex-24.05.tar.gz amrex
     codes_cmake2   \
-      -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"  \
       -DAMReX_BUILD_SHARED_LIBS=ON  \
-      -DAMReX_LINEAR_SOLVERS=ON     \
-      -DAMReX_MPI_THREAD_MULTIPLE=ON  \
-      -DAMReX_OMP=ON                \
-      -DAMReX_PARTICLES=ON          \
-      -DAMReX_SPACEDIM="1;2;3"
+      -DAMReX_LINEAR_SOLVERS=ON \
+      -DAMReX_MPI_THREAD_MULTIPLE=ON \
+      -DAMReX_OMP=ON \
+      -DAMReX_PARTICLES=ON \
+      -DAMReX_PIC=ON \
+      -DAMReX_SPACEDIM="1;2;3" \
+      -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"
     codes_cmake_build install
 }

--- a/installers/rpm-code/codes/amrex.sh
+++ b/installers/rpm-code/codes/amrex.sh
@@ -2,6 +2,7 @@
 
 amrex_main() {
     codes_dependencies common
+    # If this version is changed all dependent codes (pyamrex, impactx, warpx) must be updated.
     codes_download https://github.com/AMReX-Codes/amrex/releases/download/24.05/amrex-24.05.tar.gz amrex
     codes_cmake2   \
       -DAMReX_BUILD_SHARED_LIBS=ON  \

--- a/installers/rpm-code/codes/amrex.sh
+++ b/installers/rpm-code/codes/amrex.sh
@@ -7,6 +7,7 @@ amrex_main() {
       -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"  \
       -DAMReX_BUILD_SHARED_LIBS=ON  \
       -DAMReX_LINEAR_SOLVERS=ON     \
+      -DAMReX_MPI_THREAD_MULTIPLE=ON  \
       -DAMReX_OMP=ON                \
       -DAMReX_PARTICLES=ON          \
       -DAMReX_SPACEDIM="1;2;3"

--- a/installers/rpm-code/codes/amrex.sh
+++ b/installers/rpm-code/codes/amrex.sh
@@ -2,9 +2,13 @@
 
 amrex_main() {
     codes_dependencies common
-    codes_download https://github.com/AMReX-Codes/amrex/releases/download/22.09/amrex-22.09.tar.gz amrex
-    ./configure \
-        --prefix="${codes_dir[prefix]}"
-    codes_make
-    codes_make_install
+    codes_download https://github.com/AMReX-Codes/amrex/releases/download/24.05/amrex-24.05.tar.gz amrex
+    codes_cmake2   \
+      -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"  \
+      -DAMReX_BUILD_SHARED_LIBS=ON  \
+      -DAMReX_LINEAR_SOLVERS=ON     \
+      -DAMReX_OMP=ON                \
+      -DAMReX_PARTICLES=ON          \
+      -DAMReX_SPACEDIM="1;2;3"
+    codes_cmake_build install
 }

--- a/installers/rpm-code/codes/impactx.sh
+++ b/installers/rpm-code/codes/impactx.sh
@@ -25,10 +25,12 @@ impactx_main() {
 EOF
     codes_cmake_fix_lib_dir
     codes_cmake2  \
+      -DAMReX_MPI_THREAD_MULTIPLE=ON \
+      -DAMReX_OMP=ON \
       -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"  \
-      -DImpactX_amrex_internal=OFF                   \
-      -DImpactX_pyamrex_internal=OFF                 \
-      -DImpactX_PYTHON=ON
+      -DImpactX_PYTHON=ON \
+      -DImpactX_amrex_internal=OFF \
+      -DImpactX_pyamrex_internal=OFF
     codes_cmake_build install
     codes_cmake_build pip_install
 }

--- a/installers/rpm-code/codes/impactx.sh
+++ b/installers/rpm-code/codes/impactx.sh
@@ -26,7 +26,6 @@ impactx_main() {
 EOF
     codes_cmake_fix_lib_dir
     codes_cmake2  \
-      -DAMReX_MPI_THREAD_MULTIPLE=ON \
       -DAMReX_OMP=ON \
       -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"  \
       -DImpactX_PYTHON=ON \

--- a/installers/rpm-code/codes/impactx.sh
+++ b/installers/rpm-code/codes/impactx.sh
@@ -2,6 +2,7 @@
 
 impactx_main() {
     codes_dependencies common amrex pyamrex
+    # POSIT: Same version as amrex and pyamrex
     codes_download https://github.com/ECP-WarpX/impactx/archive/24.05.tar.gz  impactx-24.05 impactx 24.05
     # Impactx defaults to appending all options to the binary filename.
     # So, create a symlink from that name to impactx.

--- a/installers/rpm-code/codes/impactx.sh
+++ b/installers/rpm-code/codes/impactx.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 impactx_main() {
-    codes_dependencies common
-    codes_download https://github.com/ECP-WarpX/impactx/archive/24.04.tar.gz  impactx-24.04 impactx 24.04
+    codes_dependencies common amrex pyamrex
+    codes_download https://github.com/ECP-WarpX/impactx/archive/24.05.tar.gz  impactx-24.05 impactx 24.05
     # Impactx defaults to appending all options to the binary filename.
     # So, create a symlink from that name to impactx.
     # This is already done for lib files.
@@ -24,6 +24,11 @@ impactx_main() {
  #    FILE ImpactXTargets.cmake
 EOF
     codes_cmake_fix_lib_dir
-    codes_cmake2 -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"
+    codes_cmake2  \
+      -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"  \
+      -DImpactX_amrex_internal=OFF                   \
+      -DImpactX_pyamrex_internal=OFF                 \
+      -DImpactX_PYTHON=ON
     codes_cmake_build install
+    codes_cmake_build pip_install
 }

--- a/installers/rpm-code/codes/pyamrex.sh
+++ b/installers/rpm-code/codes/pyamrex.sh
@@ -2,9 +2,11 @@
 
 pyamrex_main() {
     codes_dependencies common amrex
-    codes_download https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/24.05.tar.gz pyamrex
-    codes_cmake2   \
-      -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"  \
+    codes_download https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/24.05.tar.gz pyamrex-24.05 pyamrex 24.05
+    codes_cmake_fix_lib_dir
+    codes_cmake2 \
+      -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}" \
       -DpyAMReX_amrex_internal=OFF
     codes_cmake_build install
+    codes_cmake_build pip_install
 }

--- a/installers/rpm-code/codes/pyamrex.sh
+++ b/installers/rpm-code/codes/pyamrex.sh
@@ -2,6 +2,7 @@
 
 pyamrex_main() {
     codes_dependencies common amrex
+    # POSIT: Same version as amrex
     codes_download https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/24.05.tar.gz pyamrex-24.05 pyamrex 24.05
     codes_cmake_fix_lib_dir
     codes_cmake2 \

--- a/installers/rpm-code/codes/pyamrex.sh
+++ b/installers/rpm-code/codes/pyamrex.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+pyamrex_main() {
+    codes_dependencies common amrex
+    codes_download https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/24.05.tar.gz pyamrex
+    codes_cmake2   \
+      -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"  \
+      -DpyAMReX_amrex_internal=OFF
+    codes_cmake_build install
+}

--- a/installers/rpm-code/codes/warpx.sh
+++ b/installers/rpm-code/codes/warpx.sh
@@ -1,22 +1,16 @@
 #!/bin/bash
 
-declare _warpx_src_d
-
 warpx_main() {
-    # Uses amrex, but it seems to need to build it on its own...
-    codes_dependencies common
-    codes_download https://github.com/ECP-WarpX/WarpX.git
-    _warpx_src_d=$PWD
+    codes_dependencies common amrex pyamrex
+    # POSIT: Same version as amrex and pyamrex
+    codes_download https://github.com/ECP-WarpX/WarpX/archive/refs/tags/24.05.tar.gz WarpX-24.05 warpx 24.05
     codes_cmake_fix_lib_dir
     codes_cmake2 \
         -D CMAKE_INSTALL_PREFIX="${codes_dir[prefix]}" \
         -D WarpX_APP=OFF \
         -D WarpX_DIMS='1;2;RZ;3' \
-        -D WarpX_PYTHON=ON
-}
-
-warpx_python_install() {
-    cd "$_warpx_src_d"
+        -D WarpX_PYTHON=ON \
+        -D WarpX_amrex_internal=OFF \
+        -D WarpX_pyamrex_internal=OFF
     PYINSTALLOPTIONS="--jobs=$(codes_num_cores)" codes_cmake_build pip_install
-    install -m 444 build/lib/libamrex*so "${codes_dir[lib]}"
 }


### PR DESCRIPTION
X-ref: #680 #677 #676

- [x] update AMReX to 24.05
  - [x] shared build
  - [x] add build features needed by ImpactX & WarpX
- [x] add pyAMReX 24.05
- [x] update ImpactX to 24.05
  - [x] depend on external pyAMReX and AMReX

## TODO

- [x] MPI: do you build sirepo packages with or without MPI? (We can do both, default is with MPI.)
- [x] testing (I do not know how)