### PR TITLE
Fix #700: vagrant-dev with alma

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -45,6 +45,12 @@ install_args() {
     fi
 }
 
+install_assert_centos() {
+    if [[ $install_os_release_id != almalinux ]]; then
+        install_err 'only works on RHEL like Linux'
+    fi
+}
+
 install_assert_pip_version() {
     declare package=$1
     declare version=$2
@@ -204,7 +210,7 @@ install_init_vars() {
     : ${install_version_fedora:=36}
     : ${install_version_python:=3.9.15}
     : ${install_version_python_venv:=py${install_version_python%%.*}}
-    : ${install_version_centos:=7}
+    : ${install_version_centos:=9}
     install_init_vars_oci
     eval "$(install_vars_export)"
 }
@@ -509,16 +515,12 @@ install_version_fedora_lt_36() {
 
 install_yum() {
     declare args=( "$@" )
-    declare yum=yum
-    if [[ $(type -t dnf) ]]; then
-        yum=dnf
-    fi
     declare flags=( -y --color=never )
     if [[ ! $install_debug ]]; then
         flags+=( -q )
     fi
-    install_info "$yum" "${args[@]}"
-    install_sudo "$yum" "${flags[@]}" "${args[@]}"
+    install_info dnf "${args[@]}"
+    install_sudo dnf "${flags[@]}" "${args[@]}"
 }
 
 install_yum_install() {

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -236,7 +236,7 @@ install_init_vars_os_release() {
     fi
     # COMPAT: darwin doesn't support ${x,,}
     export install_os_release_id=$(uname | tr A-Z a-z)
-    if [[ $install_os_release_id == darwin ]]; then
+    if install_os_is_darwin; then
         export install_os_release_version_id=$(sw_vers -productVersion)
     else
         # Have something legal; unlikely to get here
@@ -289,13 +289,17 @@ install_os_is_almalinux() {
     [[ $install_os_release_id =~ almalinux ]]
 }
 
-install_os_is_centos() {
+install_os_is_rhel_compatible() {
     install_os_is_almalinux || [[ $install_os_release_id =~ centos ]]
 }
 
 
 install_os_is_centos_7() {
-    install_os_is_centos && $install_version_centos -eq 7
+    install_os_is_rhel_compatible && $install_version_centos -eq 7
+}
+
+install_os_is_darwin() {
+    [[ $install_os_release_id =~ darwin ]]
 }
 
 install_os_is_fedora() {
@@ -303,7 +307,7 @@ install_os_is_fedora() {
 }
 
 install_os_is_redhat() {
-    [[ $install_os_release_id =~ rhel ]] || install_os_is_fedora || install_os_is_centos
+    [[ $install_os_release_id =~ rhel ]] || install_os_is_fedora || install_os_is_rhel_compatible
 }
 
 install_pip_install() {

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -285,8 +285,12 @@ install_not_strict_cmd() {
     set -euo pipefail
 }
 
+install_os_is_almalinux() {
+    [[ $install_os_release_id =~ almalinux ]]
+}
+
 install_os_is_centos() {
-    [[ $install_os_release_id =~ almalinux|centos ]]
+    install_os_is_almalinux || [[ $install_os_release_id =~ centos ]]
 }
 
 

--- a/installers/homebrew/radiasoft-download.sh
+++ b/installers/homebrew/radiasoft-download.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 homebrew_main() {
-    if [[ $install_os_release_id != darwin ]]; then
+    if ! install_os_is_darwin; then
         install_err "Brew is only needed on Mac OS"
     fi
     if [[ ! $(type -p git) ]]; then

--- a/installers/perl-dev/radiasoft-download.sh
+++ b/installers/perl-dev/radiasoft-download.sh
@@ -3,7 +3,9 @@
 # To run: curl radia.run | bash -s perl-dev
 #
 perl_dev_main() {
-    install_assert_centos
+    if ! install_os_is_centos; then
+        install_err 'only works on RHEL like Linux'
+    fi
     if (( $EUID == 0 )); then
         install_err 'run as vagrant (or other ordinary user), not root'
     fi

--- a/installers/perl-dev/radiasoft-download.sh
+++ b/installers/perl-dev/radiasoft-download.sh
@@ -3,9 +3,7 @@
 # To run: curl radia.run | bash -s perl-dev
 #
 perl_dev_main() {
-    if [[ $install_os_release_id != centos ]]; then
-        install_err 'only works on CentOS (RHEL) Linux'
-    fi
+    install_assert_centos
     if (( $EUID == 0 )); then
         install_err 'run as vagrant (or other ordinary user), not root'
     fi

--- a/installers/perl-dev/radiasoft-download.sh
+++ b/installers/perl-dev/radiasoft-download.sh
@@ -3,7 +3,7 @@
 # To run: curl radia.run | bash -s perl-dev
 #
 perl_dev_main() {
-    if ! install_os_is_centos; then
+    if ! install_os_is_rhel_compatible; then
         install_err 'only works on RHEL like Linux'
     fi
     if (( $EUID == 0 )); then

--- a/installers/pyenv/radiasoft-download.sh
+++ b/installers/pyenv/radiasoft-download.sh
@@ -24,7 +24,7 @@ pyenv_install() {
     # Updating the patches this way fixes the problem
     find "$PYENV_ROOT" -name \*.patch -print0 | xargs -0 -n 100 perl -pi -e 's{^(\+\+\+|--- |diff.* )\.\./}{$1}'
     install_source_bashrc
-    if [[ $install_os_release_id == darwin ]]; then
+    if install_os_is_darwin; then
         pyenv_homebrew
     fi
     export PYTHON_CONFIGURE_OPTS="${_pyenv_valgrind:+--without-pymalloc --with-pydebug --with-valgrind} --enable-shared"

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -25,6 +25,10 @@ EOF
     elif [[ ! -e /etc/yum.repos.d/epel.repo ]]; then
         yum --color=never --enablerepo=extras install -y -q epel-release
     fi
+    if [[ $install_os_release_id == almalinux ]]; then
+        # Provides packages like perl(IPC::Run) needed by moreutils (below)
+        install_yum config-manager --set-enabled crb
+    fi
     # mandb takes a really long time on some installs
     x=/usr/bin/mandb
     if [[ ! -L $x && $(readlink "$x") != true ]]; then

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -8,7 +8,7 @@ redhat_base_main() {
         return 1
     fi
     local x
-    if [[ $install_os_release_id == fedora ]]; then
+    if install_os_is_fedora; then
         x=/etc/yum.repos.d/mongodb-org-4.4.repo
         if [[ ! -e $x ]]; then
             # Use RHEL8 rpm because mongodb uses SSPL which fedora doesn't support
@@ -117,7 +117,7 @@ EOF
             xorg-x11-xauth
         )
     fi
-    if [[ $install_os_release_id == fedora ]]; then
+    if install_os_is_fedora; then
         x+=(
             perl-debugger
             direnv

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -25,7 +25,7 @@ EOF
     elif [[ ! -e /etc/yum.repos.d/epel.repo ]]; then
         yum --color=never --enablerepo=extras install -y -q epel-release
     fi
-    if [[ $install_os_release_id == almalinux ]]; then
+    if install_os_is_almalinux; then
         # Provides packages like perl(IPC::Run) needed by moreutils (below)
         install_yum config-manager --set-enabled crb
     fi

--- a/installers/redhat-dev/radiasoft-download.sh
+++ b/installers/redhat-dev/radiasoft-download.sh
@@ -3,7 +3,7 @@
 # To run: curl radia.run | bash -s redhat-dev
 #
 redhat_dev_main() {
-    if [[ ! $install_os_release_id =~ fedora|centos|rhel|alma ]]; then
+    if ! install_os_is_redhat; then
         install_err "only works on Red Hat flavored Linux (os=$install_os_release_id)"
     fi
     if (( $EUID == 0 )); then

--- a/installers/redhat-dev/radiasoft-download.sh
+++ b/installers/redhat-dev/radiasoft-download.sh
@@ -3,7 +3,7 @@
 # To run: curl radia.run | bash -s redhat-dev
 #
 redhat_dev_main() {
-    if [[ ! $install_os_release_id =~ fedora|centos|rhel ]]; then
+    if [[ ! $install_os_release_id =~ fedora|centos|rhel|alma ]]; then
         install_err "only works on Red Hat flavored Linux (os=$install_os_release_id)"
     fi
     if (( $EUID == 0 )); then

--- a/installers/redhat-dev/radiasoft-download.sh
+++ b/installers/redhat-dev/radiasoft-download.sh
@@ -10,7 +10,7 @@ redhat_dev_main() {
         install_err 'run as vagrant (or other ordinary user), not root'
     fi
     install_yum update
-    if [[ $install_os_release_id == fedora ]]; then
+    if install_os_is_fedora; then
         # this is a very an annoying feature, because it happens in every interactive shell
         install_sudo rm -f /etc/profile.d/console-login-helper-messages-profile.sh
     fi

--- a/installers/redhat-docker/radiasoft-download.sh
+++ b/installers/redhat-docker/radiasoft-download.sh
@@ -33,7 +33,7 @@ Then re-run this command
         install_err 'Disabled selinux. You need to "vagrant reload", then re-run this installer'
     fi
     declare o=rhel
-    if [[ $install_os_release_id == fedora ]]; then
+    if install_os_is_fedora; then
         dnf -y -q install dnf-plugins-core
         o=fedora
     fi
@@ -52,10 +52,12 @@ Then re-run this command
             --add-repo https://download.docker.com/linux/centos/docker-ce.repo
         yum makecache fast
         install_yum_install yum-plugin-ovl
-    else
+    elif install_os_is_rhel_compatible; then
         dnf -q config-manager \
             --add-repo \
             https://download.docker.com/linux/rhel/docker-ce.repo
+    else
+        install_err "installer does not support os=$install_os_release_id"
     fi
     install_yum_install docker-ce
     usermod -aG docker vagrant

--- a/installers/redhat-docker/radiasoft-download.sh
+++ b/installers/redhat-docker/radiasoft-download.sh
@@ -32,19 +32,15 @@ Then re-run this command
         perl -pi -e 's{(?<=^SELINUX=).*}{disabled}' /etc/selinux/config
         install_err 'Disabled selinux. You need to "vagrant reload", then re-run this installer'
     fi
-    if type dnf >& /dev/null; then
+    declare o=rhel
+    if [[ $install_os_release_id == fedora ]]; then
         dnf -y -q install dnf-plugins-core
-        dnf -q config-manager \
-            --add-repo \
-            https://download.docker.com/linux/fedora/docker-ce.repo
-        dnf -y -q install docker-ce
-    else
-        yum-config-manager \
-            --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-        yum makecache fast
-        yum -y -q install yum-plugin-ovl
-        yum -y -q install docker-ce
+        o=fedora
     fi
+    dnf -q config-manager \
+        --add-repo \
+        https://download.docker.com/linux/"$o"/docker-ce.repo
+    dnf -y -q install docker-ce
     usermod -aG docker vagrant
     install -d -m 700 /etc/docker
     mkdir -p "$data"

--- a/installers/redhat-docker/radiasoft-download.sh
+++ b/installers/redhat-docker/radiasoft-download.sh
@@ -41,6 +41,23 @@ Then re-run this command
         --add-repo \
         https://download.docker.com/linux/"$o"/docker-ce.repo
     dnf -y -q install docker-ce
+
+    if install_os_is_fedora; then
+        install_yum_install dnf-plugins-core
+        dnf -q config-manager \
+            --add-repo \
+            https://download.docker.com/linux/fedora/docker-ce.repo
+    elif install_os_is_centos_7; then
+        yum-config-manager \
+            --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+        yum makecache fast
+        install_yum_install yum-plugin-ovl
+    else
+        dnf -q config-manager \
+            --add-repo \
+            https://download.docker.com/linux/rhel/docker-ce.repo
+    fi
+    install_yum_install docker-ce
     usermod -aG docker vagrant
     install -d -m 700 /etc/docker
     mkdir -p "$data"

--- a/installers/sirepo-dev/radiasoft-download.sh
+++ b/installers/sirepo-dev/radiasoft-download.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sirepo_dev_main() {
-    if [[ $install_os_release_id != fedora ]]; then
+    if ! install_os_is_fedora; then
         install_err 'only works on Fedora Linux'
     fi
     if (( $EUID == 0 )); then

--- a/installers/slurm-dev/radiasoft-download.sh
+++ b/installers/slurm-dev/radiasoft-download.sh
@@ -7,8 +7,8 @@ slurm_dev_main() {
         install_msg 'sbatch already installed, nothing to do'
         return
     fi
-    if [[ $install_os_release_id != fedora ]]; then
-        if [[ $install_os_release_id == darwin ]]; then
+    if ! install_os_is_fedora; then
+        if install_os_is_darwin; then
             install_err 'You need to run:
 
 radia_run vagrant-dev fedora

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 #
-# Create a Centos or Fedora VirtualBox with guest additions
+# Create an Alma or Fedora VirtualBox.
+# The name centos is kept for backwards compatability but an alma
+# linux machine will be created.
 #
-# Usage: curl radia.run | bash -s vagrant-up centos|fedora [guest-name:v.radia.run [guest-ip:10.10.10.10]]
+# Usage: curl radia.run | bash -s vagrant-dev centos|alma|fedora [guest-name:v.radia.run [guest-ip:10.10.10.10]]
 #
 set -euo pipefail
 
@@ -14,20 +16,17 @@ vagrant_dev_box_add() {
     # Returns: $box
     box=$1
     declare provider=virtualbox
-    if [[ $_vagrant_dev_host_os == ubuntu ]]; then
-        provider=libvirt
-    fi
     if [[ $vagrant_dev_box ]]; then
         box=$vagrant_dev_box
     elif [[ $box =~ fedora ]]; then
         if [[ $box == fedora ]]; then
             box=generic/fedora$install_version_fedora
         fi
-    elif [[ $box == centos ]]; then
+    elif [[ $box == centos || $box == alma ]]; then
         if [[ $_vagrant_dev_host_os == ubuntu ]]; then
-            box=generic/centos$install_version_centos
+            box=generic/alma$install_version_centos
         else
-            box=centos/$install_version_centos
+            box=almalinux/$install_version_centos
         fi
     fi
     if vagrant box list | grep "$box" >& /dev/null; then
@@ -123,7 +122,7 @@ vagrant_dev_main() {
     vagrant_dev_modifiers
     for a in "$@"; do
         case $a in
-            fedora*|centos*)
+            fedora*|centos*|alma*)
                 os=$a
                 ;;
             [1-9]*)
@@ -140,11 +139,11 @@ vagrant_dev_main() {
                 ;;
             *)
                 install_err "invalid arg=$a
-expects: fedora|centos[/<version>], <ip address>, update, v[1-9].radia.run"
+expects: fedora|centos|alma[/<version>], <ip address>, update, v[1-9].radia.run"
         esac
     done
     if [[ ! $os ]]; then
-        install_err 'usage: radia_run vagrant-dev fedora|centos [host|ip] [update]'
+        install_err 'usage: radia_run vagrant-dev fedora|centos|alma [host|ip] [update]'
     fi
     if [[ ! $host ]]; then
         if [[ ! $PWD =~ /(v[2-9]?)$ ]]; then

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# Create an Alma or Fedora VirtualBox.
-# The name centos is kept for backwards compatability but an alma
-# linux machine will be created.
+# Create an AlmaLinux or Fedora VirtualBox.
+# The name centos is kept for backwards compatability but an almalinux
+# machine will be created.
 #
-# Usage: curl radia.run | bash -s vagrant-dev centos|alma|fedora [guest-name:v.radia.run [guest-ip:10.10.10.10]]
+# Usage: curl radia.run | bash -s vagrant-dev centos|almalinux|fedora [guest-name:v.radia.run [guest-ip:10.10.10.10]]
 #
 set -euo pipefail
 
@@ -16,13 +16,20 @@ vagrant_dev_box_add() {
     # Returns: $box
     box=$1
     declare provider=virtualbox
+    if [[ $_vagrant_dev_host_os == ubuntu ]]; then
+        provider=libvirt
+    fi
     if [[ $vagrant_dev_box ]]; then
         box=$vagrant_dev_box
-    elif [[ $box =~ fedora ]]; then
-        if [[ $box == fedora ]]; then
-            box=generic/fedora$install_version_fedora
+    elif [[ $box == fedora ]]; then
+        box=generic/fedora$install_version_fedora
+    elif [[ $box == centos ]]; then
+        if [[ $_vagrant_dev_host_os == ubuntu ]]; then
+            box=generic/centos$install_version_centos
+        else
+            box=centos/$install_version_centos
         fi
-    elif [[ $box == centos || $box == alma ]]; then
+    elif [[ $box == almalinux ]]; then
         if [[ $_vagrant_dev_host_os == ubuntu ]]; then
             box=generic/alma$install_version_centos
         else
@@ -31,8 +38,6 @@ vagrant_dev_box_add() {
     fi
     if vagrant box list | grep "$box" >& /dev/null; then
         vagrant box update --box "$box"
-    elif [[ $box == fedora/32-cloud-base ]]; then
-        vagrant box add https://depot.radiasoft.org/foss/fedora32-box.json
     else
         vagrant box add --provider $provider "$box"
     fi
@@ -79,7 +84,7 @@ EOF
 
 vagrant_dev_ignore_git_dir_ownership() {
     declare os="$1"
-    if [[ ! $vagrant_dev_no_nfs_src && $os =~ fedora ]]; then
+    if [[ ! $vagrant_dev_no_nfs_src && $os == fedora ]]; then
         echo 1
     fi
 }
@@ -122,7 +127,7 @@ vagrant_dev_main() {
     vagrant_dev_modifiers
     for a in "$@"; do
         case $a in
-            fedora*|centos*|alma*)
+            fedora|centos|almalinux)
                 os=$a
                 ;;
             [1-9]*)
@@ -139,11 +144,11 @@ vagrant_dev_main() {
                 ;;
             *)
                 install_err "invalid arg=$a
-expects: fedora|centos|alma[/<version>], <ip address>, update, v[1-9].radia.run"
+expects: fedora|centos|almalinux, <ip address>, update, v[1-9].radia.run"
         esac
     done
     if [[ ! $os ]]; then
-        install_err 'usage: radia_run vagrant-dev fedora|centos|alma [host|ip] [update]'
+        install_err 'usage: radia_run vagrant-dev fedora|centos|almalinux [host|ip] [update]'
     fi
     if [[ ! $host ]]; then
         if [[ ! $PWD =~ /(v[2-9]?)$ ]]; then

--- a/installers/vagrant-perl-dev/radiasoft-download.sh
+++ b/installers/vagrant-perl-dev/radiasoft-download.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 vagrant_perl_dev_main() {
-    vagrant_dev_post_install_repo=perl-dev install_repo_eval vagrant-dev centos/7 "$@"
+    vagrant_dev_post_install_repo=perl-dev install_repo_eval vagrant-dev centos "$@"
 }


### PR DESCRIPTION
The name centos is left for backwards compat. One can also supply the name alma to the installer.

This doesn't resolve all possible issues related to CentOS in downloads but just gets the vagrant-dev installer working.