### PR TITLE
Fix #707: Flag to set dev vs rsconf environments.

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -295,7 +295,7 @@ install_os_is_rhel_compatible() {
 
 
 install_os_is_centos_7() {
-    install_os_is_rhel_compatible && $install_version_centos -eq 7
+    install_os_is_rhel_compatible && [[ $install_version_centos -eq 7 ]]
 }
 
 install_os_is_darwin() {

--- a/installers/redhat-docker/radiasoft-download.sh
+++ b/installers/redhat-docker/radiasoft-download.sh
@@ -25,23 +25,13 @@ umount /var/lib/docker
 rmdir /var/lib/docker
 perl -pi -e "s{^/var/lib/docker.*}{}" /etc/fstab
 
-Then re-run this command
+Then re-run this command. This should only happen in development environments.
 '
     fi
     if selinuxenabled; then
         perl -pi -e 's{(?<=^SELINUX=).*}{disabled}' /etc/selinux/config
         install_err 'Disabled selinux. You need to "vagrant reload", then re-run this installer'
     fi
-    declare o=rhel
-    if install_os_is_fedora; then
-        dnf -y -q install dnf-plugins-core
-        o=fedora
-    fi
-    dnf -q config-manager \
-        --add-repo \
-        https://download.docker.com/linux/"$o"/docker-ce.repo
-    dnf -y -q install docker-ce
-
     if install_os_is_fedora; then
         install_yum_install dnf-plugins-core
         dnf -q config-manager \
@@ -60,6 +50,9 @@ Then re-run this command
         install_err "installer does not support os=$install_os_release_id"
     fi
     install_yum_install docker-ce
+    if [[ ! ${redhat_docker_dev:-} ]]; then
+        return 0
+    fi
     usermod -aG docker vagrant
     install -d -m 700 /etc/docker
     mkdir -p "$data"


### PR DESCRIPTION
This installer is going to be called by rsconf to setup docker on rsconf managed hosts. We only want to to do the tls, systemd, daemon.json, and systemctl steps on "dev" hosts. On rsconf managed hosts rsconf will manage the files and do the systemctl's.