### PR TITLE
Fix #703: vagrant-rsconf-dev working for almalinux

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -369,6 +369,7 @@ install_repo_as_user() {
             install_channel="$install_channel" \
             install_debug="$install_debug" \
             install_depot_server="$install_depot_server" \
+            install_version_centos="$install_version_centos" \
             bash -l -s "$@"
     )
 }
@@ -520,6 +521,7 @@ install_vars_export() {
         install_proprietary_key \
         install_version_fedora \
         install_version_python \
+        install_version_centos \
         $(compgen -A variable RADIA_RUN_) \
         $(compgen -A variable GITHUB_)
     do

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -121,6 +121,10 @@ EOF
         x+=(
             perl-debugger
             direnv
+        )
+    fi
+    if ! install_os_is_centos_7; then
+        x+=(
             opendkim-tools
         )
     fi

--- a/installers/redhat-dev/radiasoft-download.sh
+++ b/installers/redhat-dev/radiasoft-download.sh
@@ -9,6 +9,11 @@ redhat_dev_main() {
     if (( $EUID == 0 )); then
         install_err 'run as vagrant (or other ordinary user), not root'
     fi
+    if install_os_is_centos_7; then
+        install_sudo sed -i.bak -e 's,^mirrorlist=http://mirrorlist,#mirrorlist=http://vault,' -e 's,^#baseurl=http://mirror.centos.org,baseurl=https://depot.radiasoft.org/yum,' /etc/yum.repos.d/CentOS-Base.repo
+        install_yum clean all
+        install_yum makecache
+    fi
     install_yum update
     if install_os_is_fedora; then
         # this is a very an annoying feature, because it happens in every interactive shell

--- a/installers/redhat-docker/radiasoft-download.sh
+++ b/installers/redhat-docker/radiasoft-download.sh
@@ -25,23 +25,13 @@ umount /var/lib/docker
 rmdir /var/lib/docker
 perl -pi -e "s{^/var/lib/docker.*}{}" /etc/fstab
 
-Then re-run this command
+Then re-run this command. This should only happen in development environments.
 '
     fi
     if selinuxenabled; then
         perl -pi -e 's{(?<=^SELINUX=).*}{disabled}' /etc/selinux/config
         install_err 'Disabled selinux. You need to "vagrant reload", then re-run this installer'
     fi
-    declare o=rhel
-    if install_os_is_fedora; then
-        dnf -y -q install dnf-plugins-core
-        o=fedora
-    fi
-    dnf -q config-manager \
-        --add-repo \
-        https://download.docker.com/linux/"$o"/docker-ce.repo
-    dnf -y -q install docker-ce
-
     if install_os_is_fedora; then
         install_yum_install dnf-plugins-core
         dnf -q config-manager \
@@ -60,6 +50,9 @@ Then re-run this command
         install_err "installer does not support os=$install_os_release_id"
     fi
     install_yum_install docker-ce
+    if [[ ! ${redhat_docker_dev:-} ]]; then
+        return 0
+    fi
     usermod -aG docker vagrant
     install -d -m 700 /etc/docker
     mkdir -p "$data"

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -48,7 +48,8 @@ vagrant_dev_disable_security() {
 sudo bash <<'EOF_BASH'
 systemctl stop firewalld || true
 systemctl disable firewalld || true
-perl -pi -e 's{(?<=^SELINUX=).*}{disabled}' /etc/selinux/config
+# Early in setup so perl might not yet be installed. Use sed instead.
+sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/selinux/config
 EOF_BASH
 EOF
     vagrant reload


### PR DESCRIPTION
This installer is going to be called by rsconf to setup docker on rsconf managed hosts. We only want to to do the tls, systemd, daemon.json, and systemctl steps on "dev" hosts. On rsconf managed hosts rsconf will manage the files and do the systemctl's.

Fix #705: centos7 is eol so need to use radiasoft depot mirror.
Fix #704: perl not yet installed so use sed
Fix #707: Flag to set dev vs rsconf environments.