### PR TITLE
Fix #688: update amrex, pyamrex, impactx, and warpx.

### DIFF
--- a/installers/rpm-code/codes/amrex.sh
+++ b/installers/rpm-code/codes/amrex.sh
@@ -3,7 +3,8 @@
 amrex_main() {
     codes_dependencies common
     # If this version is changed all dependent codes (pyamrex, impactx, warpx) must be updated.
-    codes_download https://github.com/AMReX-Codes/amrex/releases/download/24.05/amrex-24.05.tar.gz amrex
+    codes_download https://github.com/AMReX-Codes/amrex/releases/download/24.09/amrex-24.09.tar.gz amrex
+    # AMReX_TINY_PROFILE=ON added because of https://github.com/ECP-WarpX/WarpX/issues/5295
     codes_cmake2   \
       -DAMReX_BUILD_SHARED_LIBS=ON  \
       -DAMReX_LINEAR_SOLVERS=ON \
@@ -12,6 +13,7 @@ amrex_main() {
       -DAMReX_PARTICLES=ON \
       -DAMReX_PIC=ON \
       -DAMReX_SPACEDIM="1;2;3" \
+      -DAMReX_TINY_PROFILE=ON \
       -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}"
     codes_cmake_build install
 }

--- a/installers/rpm-code/codes/impactx.sh
+++ b/installers/rpm-code/codes/impactx.sh
@@ -3,7 +3,7 @@
 impactx_main() {
     codes_dependencies common amrex openpmdapi pyamrex
     # POSIT: Same version as amrex and pyamrex
-    codes_download https://github.com/ECP-WarpX/impactx/archive/24.05.tar.gz  impactx-24.05 impactx 24.05
+    codes_download https://github.com/ECP-WarpX/impactx/archive/24.09.tar.gz  impactx-24.09 impactx 24.09
     # Impactx defaults to appending all options to the binary filename.
     # So, create a symlink from that name to impactx.
     # This is already done for lib files.
@@ -32,6 +32,12 @@ EOF
       -DImpactX_amrex_internal=OFF \
       -DImpactX_openpmd_internal=OFF \
       -DImpactX_pyamrex_internal=OFF
+    # TODO(e-carlin): When
+    # https://github.com/ECP-WarpX/impactx/issues/634 is fixed we can
+    # remove this and instead create rscode-ablastr and depend on it.
+    # rscode-warpx also installs ablastr so this would conflict with
+    # it.
+    echo '' > build/_deps/fetchedablastr-build/cmake_install.cmake
     codes_cmake_build install
     codes_cmake_build pip_install
 }

--- a/installers/rpm-code/codes/openpmdapi.sh
+++ b/installers/rpm-code/codes/openpmdapi.sh
@@ -2,9 +2,9 @@
 
 openpmdapi_main() {
     codes_dependencies common
-    # POSIT: Version that impactx and waprx want
-    # https://github.com/ECP-WarpX/impactx/blob/24.05/cmake/dependencies/ABLASTR.cmake#L197
-    # https://github.com/ECP-WarpX/WarpX/blob/24.05/cmake/dependencies/openPMD.cmake#L95
+    # POSIT: Version that impactx and warpx want
+    # https://github.com/ECP-WarpX/impactx/blob/24.09/cmake/dependencies/ABLASTR.cmake#L180
+    # https://github.com/ECP-WarpX/WarpX/blob/24.09/cmake/dependencies/openPMD.cmake#L90
     codes_download https://github.com/openPMD/openPMD-api/archive/refs/tags/0.15.2.tar.gz openPMD-api-0.15.2 openpmdapi 0.15.2
     codes_cmake_fix_lib_dir
     codes_cmake2  \

--- a/installers/rpm-code/codes/pyamrex.sh
+++ b/installers/rpm-code/codes/pyamrex.sh
@@ -3,7 +3,7 @@
 pyamrex_main() {
     codes_dependencies common amrex
     # POSIT: Same version as amrex
-    codes_download https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/24.05.tar.gz pyamrex-24.05 pyamrex 24.05
+    codes_download https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/24.09.tar.gz pyamrex-24.09 pyamrex 24.09
     codes_cmake_fix_lib_dir
     codes_cmake2 \
       -DCMAKE_INSTALL_PREFIX="${codes_dir[prefix]}" \

--- a/installers/rpm-code/codes/warpx.sh
+++ b/installers/rpm-code/codes/warpx.sh
@@ -3,15 +3,15 @@
 warpx_main() {
     codes_dependencies common amrex openpmdapi pyamrex
     # POSIT: Same version as amrex and pyamrex
-    codes_download https://github.com/ECP-WarpX/WarpX/archive/refs/tags/24.05.tar.gz WarpX-24.05 warpx 24.05
+    codes_download https://github.com/ECP-WarpX/WarpX/archive/refs/tags/24.09.tar.gz WarpX-24.09 warpx 24.09
     codes_cmake_fix_lib_dir
     codes_cmake2 \
         -D CMAKE_INSTALL_PREFIX="${codes_dir[prefix]}" \
-        -D WarpX_APP=OFF \
         -D WarpX_DIMS='1;2;RZ;3' \
         -D WarpX_PYTHON=ON \
         -D WarpX_amrex_internal=OFF \
         -D WarpX_openpmd_internal=OFF \
         -D WarpX_pyamrex_internal=OFF
+    codes_cmake_build install
     PYINSTALLOPTIONS="--jobs=$(codes_num_cores)" codes_cmake_build pip_install
 }


### PR DESCRIPTION
- Add warpx apps (binaires and libraries) back in
- Remove ablastr static library install from impactx. Warpx installs them.