### PR TITLE
Fix #735: Don't configure eth1 on almalinux

### DIFF
--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -57,7 +57,7 @@ EOF
 vagrant_dev_eth1() {
     declare os=$1
     declare ip=$2
-    if [[ $os == fedora && $vagrant_dev_private_net ]]; then
+    if ! install_os_is_almalinux && [[ $os == fedora && $vagrant_dev_private_net ]]; then
         # Vagrant doesn't handle NetworkManager correctly so setup eth1
         # https://github.com/hashicorp/vagrant/issues/12762
         cat <<EOF


### PR DESCRIPTION
On alma we are running into trouble where two interfaces with the same network were being created. Likely one from vagrant/vbox and one from the nmcli command. This was causing trouble during install of the vm where it could no longer be accessed over ssh.