### PR TITLE
Fix #727: add curl --fail

### DIFF
--- a/bin/index.sh
+++ b/bin/index.sh
@@ -20,7 +20,7 @@ index_main() {
             https://api.github.com/repos/radiasoft/download/contents/bin/install.sh
         )
     fi
-    curl --silent --show-error "${a[@]}" | bash ${install_debug:+-x} -s "$@"
+    curl --fail --silent --show-error "${a[@]}" | bash ${install_debug:+-x} -s "$@"
 }
 
 index_main "$@"


### PR DESCRIPTION
Makes it easier to detect errors (e.g., bad GITHUB_TOKEN)