### PR TITLE
Fix #760 support dnf5 and support fedora 42 in general

### DIFF
--- a/bin/index.sh
+++ b/bin/index.sh
@@ -7,10 +7,9 @@ shopt -s nullglob
 
 index_main() {
     declare -a a=()
-    # POSIT: install.sh defaults to github
-    if [[ ${install_server:-} && $install_server != github ]]; then
-        a+=( "$install_server/radiasoft/download/bin/install.sh" )
-    else
+    # POSIT: install.sh defaults to radia.run
+    declare u=${install_server:-https://radia.run}
+    if [[ $u == github ]]; then
         if [[ ${GITHUB_TOKEN:-} ]]; then
             a+=( --header "Authorization: Bearer $GITHUB_TOKEN" )
         fi
@@ -18,8 +17,10 @@ index_main() {
             --header 'Accept: application/vnd.github.raw'
             https://api.github.com/repos/radiasoft/download/contents/bin/install.sh
         )
+    else
+        a+=( "$u/radiasoft/download/bin/install.sh" )
     fi
-    curl --fail --location --show-error --silent "${a[@]}" | bash "${install_debug:+-x}" -s "$@"
+    curl --fail --location --show-error --silent "${a[@]}" | install_server="$u" bash "${install_debug:+-x}" -s "$@"
 }
 
 index_main "$@"

--- a/bin/index.sh
+++ b/bin/index.sh
@@ -2,15 +2,14 @@
 #
 # See https://github.com/radiasoft/download
 #
-set -e -o pipefail
+set -euo pipefail
+shopt -s nullglob
 
 index_main() {
     declare -a a=()
+    # POSIT: install.sh defaults to github
     if [[ ${install_server:-} && $install_server != github ]]; then
-        a=(
-            --location
-            "$install_server/radiasoft/download/bin/install.sh"
-        )
+        a+=( "$install_server/radiasoft/download/bin/install.sh" )
     else
         if [[ ${GITHUB_TOKEN:-} ]]; then
             a+=( --header "Authorization: Bearer $GITHUB_TOKEN" )
@@ -20,7 +19,7 @@ index_main() {
             https://api.github.com/repos/radiasoft/download/contents/bin/install.sh
         )
     fi
-    curl --silent --show-error "${a[@]}" | bash ${install_debug:+-x} -s "$@"
+    curl --fail --location --show-error --silent "${a[@]}" | bash "${install_debug:+-x}" -s "$@"
 }
 
 index_main "$@"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -458,7 +458,9 @@ install_script_eval() {
         fi
     fi
     install_info "Source: $source"
-    source "$source"
+    if ! source "$source"; then
+        install_err "Error in script=$script"
+    fi
     if [[ $m && $(type -t "$m") == function ]]; then
         $m ${install_extra_args[@]+"${install_extra_args[@]}"}
     fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -166,10 +166,14 @@ If you don't know what to do, please contact support@radiasoft.net."
 }
 
 install_err_stack() {
-    if (( ! $# )); then
+    if (( $# <= 1)); then
         return
     fi
     declare funcs=( "$@" )
+    if [[ "${funcs[1]}" == install_err_trap ]]; then
+        # install_err called by install_err_trap, stack already printed
+        return
+    fi
     declare f
     install_msg 'bash stack:'
     for f in "${funcs[@]:1}"; do

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -559,13 +559,14 @@ install_yum() {
 
 install_yum_add_repo() {
     declare repo=$1
-    # Guess at os incompatibility with new dnf upgrade
-    if [[ $(type -t dnf6) ]]; then
-        install_err 'dnf6 or above is not supported'
-    elif [[ $(type -t dnf5) ]]; then
+    if [[ $(type -t dnf5) ]]; then
+        if [[ $(readlink /usr/bin/dnf) != dnf5 ]]; then
+            install_err 'dnf6 or above is not supported'
+        fi
         install_yum_install dnf-plugins-core
         install_yum addrepo --from-repofile="$repo"
     elif [[ $(type -t dnf) ]]; then
+        # dnf 4 or before
         install_yum_install dnf-plugins-core
         install_yum config-manager --add-repo "$repo"
     elif [[ $(type -t yum-config-manager) ]]; then

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -438,7 +438,7 @@ install_script_eval() {
         install_err "$script: no #! at start of file: $source"
     fi
     # Caculate main function before sourcing
-    declare m=$(basename script .sh)
+    declare m=$(basename "$script" .sh)
     if [[ "$script" == radiasoft-download.sh ]]; then
         declare f
         # POSIT: same special case in install_url()
@@ -453,7 +453,7 @@ install_script_eval() {
     # three cases: main without args or with install_extra_args
     # Be loose in case there's a bug. Compliant scripts must
     # not call main in any form
-    if grep -E "^$f( *| .*@.*)$" "$source" >&/dev/null; then
+    if grep -E "^$m( *| .*@.*)$" "$source" >&/dev/null; then
         # main is called in script so don't call again
         m=
     else

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -539,13 +539,17 @@ install_version_fedora_lt_36() {
 
 install_yum() {
     declare args=( "$@" )
+    declare cmd=$1
     declare yum=yum
     declare flags=( -y )
     if [[ $(type -t dnf5) ]]; then
         yum=dnf5
     else
-        # dnf5 does not support --color
-        flags+=( ---color=never )
+        # dnf5 and config-manager do not support --color
+        # install and update are the only problematic outputs
+        if [[ $cmd =~ install|update ]]; then
+            flags+=( ---color=never )
+        fi
         if [[ $(type -t dnf) ]]; then
             yum=dnf
         fi
@@ -554,7 +558,8 @@ install_yum() {
         flags+=( -q )
     fi
     install_info "$yum" "${args[@]}"
-    install_sudo "$yum" "${flags[@]}" "${args[@]}"
+    # cat prevents color output in dnf5
+    install_sudo "$yum" "${flags[@]}" "${args[@]}" | cat
 }
 
 install_yum_add_repo() {

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -151,9 +151,10 @@ install_git_clone() {
 }
 
 install_err() {
+    declare -a msg=( "$@" )
     trap - EXIT
-    if [[ -n $1 ]]; then
-        install_msg "$*
+    if (( ${#msg[@]} > 0 )); then
+        install_msg "${args[*]}
 If you don't know what to do, please contact support@radiasoft.net."
     fi
     if [[ -z $install_verbose ]]; then
@@ -462,9 +463,8 @@ install_script_eval() {
         cd "$pwd"
     fi
     declare source=$install_script_dir/$(date +%Y%m%d%H%M%S)-$(basename "$script")
-    install_download "$script" > "$source"
-    if [[ ! -s $source ]]; then
-        install_err
+    if ! install_download "$script" > "$source" || [[ ! -s $source ]]; then
+        install_err "error downloading script=$script"
     fi
     if [[ ! $(head -1 "$source") =~ ^#! ]]; then
         install_err "$script: no #! at start of file: $source"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Usage: curl https://depot.radiasoft.org | bash -s [repo args...]
+# Usage: curl https://radia.run | bash -s repo [args...]
 #
 # Find repos in radiasoft/download/installers or radiasoft/*/radiasoft-download.sh
 # or any repo with a radiasoft-download.sh in its root.
@@ -41,7 +41,8 @@ install_args() {
         set -x
     fi
     if [[ ! $install_repo ]]; then
-        install_repo=$install_default_repo
+        install_err "Usage: curl $install_server | bash -s repo [args...]
+Must supply repo argument"
     fi
 }
 
@@ -185,9 +186,9 @@ install_log() {
 }
 
 install_init_vars() {
+    install_init_vars_servers
     install_init_vars_basic_options
     install_init_vars_basic
-    install_init_vars_servers
     install_init_vars_versions
     install_init_vars_virt
     install_init_vars_oci
@@ -223,7 +224,6 @@ install_init_vars_basic_options() {
         install_channel=prod
         install_channel_is_default=1
     fi
-    : ${install_default_repo:=container-run}
     : ${install_proprietary_key:=missing-proprietary-key}
     : ${install_verbose:=}
 }

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -545,11 +545,8 @@ install_yum() {
     if [[ $(type -t dnf5) ]]; then
         yum=dnf5
     else
-        # dnf5 and config-manager do not support --color
-        # install and update are the only problematic outputs
-        if [[ $cmd =~ install|update ]]; then
-            flags+=( ---color=never )
-        fi
+        # dnf5 does not support --color
+        flags+=( --color=never )
         if [[ $(type -t dnf) ]]; then
             yum=dnf
         fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -183,6 +183,7 @@ install_init_vars() {
     install_init_vars_virt
     : ${install_debug:=}
     : ${install_default_repo:=container-run}
+    # POSIT: index.sh defaults to github
     : ${install_server:=github}
     : ${install_tmp_dir:=/var/tmp}
     : ${install_verbose:=}

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -419,7 +419,7 @@ install_script_eval() {
         # three cases: main without args or with install_extra_args
         # Be loose in case there's a bug. Compliant scripts must
         # not call main in any form
-        if ! egrep "^$f( *| .*@.*)$" "$source" >&/dev/null; then
+        if ! grep -E "^$f( *| .*@.*)$" "$source" >&/dev/null; then
             m=$f
             # Just in case repo was evaled already
             unset "$m"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -154,7 +154,7 @@ install_err() {
     declare -a msg=( "$@" )
     trap - EXIT
     if (( ${#msg[@]} > 0 )); then
-        install_msg "${args[*]}
+        install_msg "${msg[*]}
 If you don't know what to do, please contact support@radiasoft.net."
     fi
     if [[ -z $install_verbose ]]; then

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -551,7 +551,9 @@ install_yum() {
     if [[ ! $install_debug ]]; then
         flags+=( -q )
     fi
-    install_info "$yum" "${args[@]}"
+    if [[ ${args[0]} != repolist ]]; then
+        install_info "$yum" "${args[@]}"
+    fi
     # cat prevents color output in dnf5
     install_sudo "$yum" "${flags[@]}" "${args[@]}" | cat
 }

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -203,7 +203,7 @@ install_init_vars_basic() {
         install_log_file=/tmp/$(date +%Y%m%d%H%M%S)-$RANDOM-$(basename "$install_log_file")
     fi
     install_extra_args=()
-    install_prog="curl $install_depot_server | bash -s"
+    install_prog="curl $install_server | bash -s"
     install_repo=
     install_script_dir=
     if [[ ! -w $install_tmp_dir ]]; then

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -531,10 +531,7 @@ install_vars_export() {
 }
 
 install_version_fedora_lt_36() {
-    if (( $install_version_fedora < 36 )); then
-        return 0
-    fi
-    return 1
+    (( $install_version_fedora < 36 ))
 }
 
 install_yum() {
@@ -561,6 +558,9 @@ install_yum() {
 
 install_yum_add_repo() {
     declare repo=$1
+    if [[ -r /etc/yum.repos.d/${repo##*/} ]]; then
+        return
+    fi
     if [[ $(type -t dnf5) ]]; then
         if [[ $(readlink /usr/bin/dnf) != dnf5 ]]; then
             install_err 'dnf6 or above is not supported'
@@ -580,6 +580,11 @@ install_yum_add_repo() {
 }
 
 install_yum_install() {
+    declare -a flags=()
+    while [[ ${1:-} =~ ^- ]]; do
+        flags+=( "$1" )
+        shift
+    done
     declare x y todo=()
     for x in "$@"; do
         y=$x
@@ -600,7 +605,7 @@ install_yum_install() {
     if (( ${#todo[@]} <= 0 )); then
         return
     fi
-    install_yum install "${todo[@]}"
+    install_yum install "${flags[@]}" "${todo[@]}"
 }
 
 install_main "$@"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -459,10 +459,12 @@ install_script_eval() {
     fi
     install_info "Source: $source"
     if ! source "$source"; then
-        install_err "Error in script=$script"
+        install_err "Error sourcing script=$script"
     fi
     if [[ $m && $(type -t "$m") == function ]]; then
-        $m ${install_extra_args[@]+"${install_extra_args[@]}"}
+        if ! $m ${install_extra_args[@]+"${install_extra_args[@]}"}; then
+            install_err "Error in function=$m script=$script"
+        fi
     fi
 }
 

--- a/installers/code/radiasoft-download.sh
+++ b/installers/code/radiasoft-download.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 #
-# To run: curl radia.run | bash -s code warp
+# To run: curl radia.run | bash -s code srw
 #
 code_main() {
-    local dnf=( dnf --color=never -y )
     if [[ ! -e /etc/yum.repos.d/radiasoft.repo ]]; then
-        if ! rpm -q dnf-plugins-core >& /dev/null; then
-            "${dnf[@]}" dnf-plugins-core
-        fi
         #TODO(robnagler) always install from dev? Since we promote binaries, makes sense.
-        install_sudo "${dnf[@]}" config-manager --add-repo "$(install_depot_server)/yum/$install_os_release_id/$install_os_release_version_id/$(arch)/dev/radiasoft.repo"
+        install_yum_add_repo "$(install_depot_server)/yum/$install_os_release_id/$install_os_release_version_id/$(arch)/dev/radiasoft.repo"
     fi
     if [[ ! ${install_extra_args:+1} ]]; then
         echo 'List of available codes:'
-        "${dnf[@]}" repoquery --queryformat '%{NAME}' rscode-\* | perl -pe 's/^rscode-//'
+        declare f='%{name}'
+        if [[ $(type -t dnf5) ]]; then
+            f+='\n'
+        fi
+        install_yum repoquery --queryformat "$f" rscode-\* | perl -pe 's/^rscode-//'
         return 1
     fi
     local rpms=()

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -92,7 +92,7 @@ _redhat_base_pkgs() {
 
 _redhat_base_profile_d() {
     # POSIT: install_file_from_stdin doesn't use other install_*
-    install_sudo bash -euo pipefail <<"END_SUDO"
+    install_sudo bash -euo pipefail <<<END_SUDO
 $(declare -f install_file_from_stdin)
 echo "export RADIA_RUN_SERVER='$install_server'" \
     | install_file_from_stdin 444 root root /etc/profile.d/rs-redhat-base.sh

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -92,7 +92,7 @@ _redhat_base_pkgs() {
 
 _redhat_base_profile_d() {
     # POSIT: install_file_from_stdin doesn't use other install_*
-    install_sudo bash -euo pipefail <<<END_SUDO
+    install_sudo bash -euo pipefail <<END_SUDO
 $(declare -f install_file_from_stdin)
 echo "export RADIA_RUN_SERVER='$install_server'" \
     | install_file_from_stdin 444 root root /etc/profile.d/rs-redhat-base.sh

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -62,7 +62,6 @@ EOF
         biosdevname
         bzip2
         bzip2-devel
-        createrepo
         emacs-nox
         gcc
         gcc-c++
@@ -89,7 +88,6 @@ EOF
         openssl-devel
         patch
         pciutils
-        pkgconfig
         procps-ng
         pxz
         readline-devel
@@ -112,22 +110,15 @@ EOF
         zlib-devel
     )
     if [[ ! ${install_virt_docker:-} ]]; then
-        x+=(
-            lvm2
-            # for ssh x11 forwarding
-            xorg-x11-xauth
-        )
+        x+=( lvm2 xorg-x11-xauth )
     fi
     if install_os_is_fedora; then
-        x+=(
-            perl-debugger
-            direnv
-        )
+        x+=( perl-debugger direnv )
     fi
-    if ! install_os_is_centos_7; then
-        x+=(
-            opendkim-tools
-        )
+    if install_os_is_centos_7; then
+        x+=( createrepo pkgconfig )
+    else
+        x+=( createrepo_c opendkim-tools pkgconf-pkg-config )
     fi
     install_yum_install "${x[@]}"
 }

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -22,11 +22,12 @@ gpgkey=https://www.mongodb.org/static/pgp/server-4.4.asc
 includepkgs=mongodb-org-server
 EOF
         fi
-    elif [[ ! -e /etc/yum.repos.d/epel.repo ]]; then
-        yum --color=never --enablerepo=extras install -y -q epel-release
+    else
+        install_yum_install --enablerepo=extras epel-release
     fi
-    if install_os_is_almalinux; then
+    if install_os_is_almalinux && ! install_yum repolist | grep -q '^crb '; then
         # Provides packages like perl(IPC::Run) needed by moreutils (below)
+        # TODO(robnagler) will break with dnf5, probably
         install_yum config-manager --set-enabled crb
     fi
     # mandb takes a really long time on some installs

--- a/installers/redhat-docker-install/radiasoft-download.sh
+++ b/installers/redhat-docker-install/radiasoft-download.sh
@@ -3,19 +3,12 @@ set -euo pipefail
 
 redhat_docker_install_main() {
     if install_os_is_fedora; then
-        install_yum_install dnf-plugins-core
-        dnf -q config-manager \
-            --add-repo \
-            https://download.docker.com/linux/fedora/docker-ce.repo
+        install_yum_add_repo https://download.docker.com/linux/fedora/docker-ce.repo
     elif install_os_is_centos_7; then
-        yum-config-manager \
-            --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-        yum makecache fast
+        install_yum_add_repo https://download.docker.com/linux/centos/docker-ce.repo
         install_yum_install yum-plugin-ovl
     elif install_os_is_rhel_compatible; then
-        dnf -q config-manager \
-            --add-repo \
-            https://download.docker.com/linux/rhel/docker-ce.repo
+        install_yum_add_repo https://download.docker.com/linux/rhel/docker-ce.repo
     else
         install_err "installer does not support os=$install_os_release_id"
     fi

--- a/installers/rpm-code/codes/epics.sh
+++ b/installers/rpm-code/codes/epics.sh
@@ -21,7 +21,7 @@ epics_install() {
     rm -rf modules documentation html src test
     find lib -name '*.a' | xargs -n 100 rm -f
     cd bin/"$a"
-    ls | egrep -v '^S99|\.p[lm]$' | xargs -I % install -m 555 % "${codes_dir[bin]}"
+    ls | grep -E -v '^S99|\.p[lm]$' | xargs -I % install -m 555 % "${codes_dir[bin]}"
 }
 
 epics_main() {

--- a/installers/rpm-code/codes/pymesh.sh
+++ b/installers/rpm-code/codes/pymesh.sh
@@ -36,7 +36,7 @@ pymesh_main() {
     # fmt is strange, can't specify depth
     #    git submodule update --init --recursive third_party/fmt
     # cgal is very large so use --depth=5 fmt needs --depth=10
-    #    git submodule update --init --depth=5 $(find third_party/* -maxdepth 0 -type d | egrep -iv '(geogram|fmt|mmg|cgal)')
+    #    git submodule update --init --depth=5 $(find third_party/* -maxdepth 0 -type d | grep -E -iv '(geogram|fmt|mmg|cgal)')
 }
 
 pymesh_patch_numpy_testing() {

--- a/installers/rpm-code/dnf-download-all.sh
+++ b/installers/rpm-code/dnf-download-all.sh
@@ -6,5 +6,4 @@ set +euo pipefail
 source ~/.bashrc
 set -euo pipefail
 source ./dev-env.sh
-sudo dnf makecache
 install_server= radia_run beamsim-codes build ./dnf-download.sh "${1:-}"

--- a/installers/slurm-dev/radiasoft-download.sh
+++ b/installers/slurm-dev/radiasoft-download.sh
@@ -29,7 +29,7 @@ radia_run slurm-dev
         n=1
         slurm_dev_nfs
     fi
-    install_yum install slurm-slurmd slurm-slurmctld
+    install_yum_install slurm-slurmd slurm-slurmctld
     declare k=/etc/munge/munge.key
     if ! install_sudo test -e "$k"; then
         dd if=/dev/urandom bs=1 count=1024 \
@@ -54,7 +54,7 @@ slurm_dev_nfs() {
     if grep -s -q $_slurm_dev_nfs_server:/home/vagrant /etc/fstab; then
         return
     fi
-    install_yum install nfs-utils
+    install_yum_install nfs-utils
     if ! showmount -e "$_slurm_dev_nfs_server" >&/dev/null; then
         install_err "
 on $_slurm_dev_nfs_server you need to:

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -150,7 +150,7 @@ expects: fedora|centos|almalinux, <ip address>, update, v[1-9].radia.run"
         install_err 'usage: radia_run vagrant-dev fedora|centos|almalinux [host|ip] [update]'
     fi
     if [[ $install_server =~ ^file: ]]; then
-        install_error "File URLs do not work in VM install_server=$install_server
+        install_err "File URLs do not work in VM install_server=$install_server
 Set up a development server"
     fi
     if [[ ! $host ]]; then

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -189,8 +189,8 @@ Set up a development server"
     install_info 'Running installer: redhat-dev'
     vagrant ssh <<EOF
 $(install_vars_export)
-curl $(install_server)/index.sh | \
-  bivio_home_env_ignore_git_dir_ownership=$(vagrant_dev_ignore_git_dir_ownership $os) \
+curl '$install_server/index.sh' | \
+  bivio_home_env_ignore_git_dir_ownership='$(vagrant_dev_ignore_git_dir_ownership $os)' \
   bash -s redhat-dev
 EOF
     vagrant_dev_post_install "$update"

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -460,6 +460,7 @@ EOF
 # -*-ruby-*-
 Vagrant.configure("2") do |config|
     config.vm.box = "$box"
+    config.vm.box_check_update = false
     config.vm.hostname = "$host"
 $(vagrant_dev_private_net "$ip")
 $provider

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -36,10 +36,8 @@ vagrant_dev_box_add() {
             box=almalinux/$install_version_centos
         fi
     fi
-    if vagrant box list | grep "$box" >& /dev/null; then
-        vagrant box update --box "$box"
-    else
-        vagrant box add --provider $provider "$box"
+    if ! vagrant box list | grep -q "$box" >& /dev/null; then
+        vagrant box add --provider "$provider" "$box"
     fi
 }
 


### PR DESCRIPTION
- Fix radiasoft/download#761 added /etc/profile.d/rs-redhat-base.sh which defines RADIA_RUN_SERVER
- Fix radiasoft/download#758 do not check box updates in vagrant-dev
- Improved run-time error handling (prints stack)
- Fixed errexit suppression issues
- e/fgrep references removed
- Fix radiasoft/download#764 vagrant-dev support libvirt forwarding (`:libvirt__forward_mode: "open"`)