### PR TITLE
Fix #869 install_git_clone use credential.helper

### DIFF
--- a/etc/dev-server.sh
+++ b/etc/dev-server.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eou pipefail
 cd ~/src
-declare host=${1:-}
 declare index_sh=radiasoft/download/bin/index.sh
 if [[ ! -r $index_sh ]]; then
     echo "Expect $PWD/$index_sh to exist, see README.md"
@@ -14,31 +13,18 @@ for f in index.html index.sh; do
         ln -s "$index_sh" "$f"
     fi
 done
-if [[ ! $host ]]; then
-    host=$(dig $(hostname -f || true) +short || true)
-    if [[ ! $host && $(type -p ipconfig) ]]; then
-        host=$(ipconfig getifaddr en0)
-    fi
-    if [[ ! $host ]]; then
-        cat <<EOF
-Unable to determine ip address of this host. Supply on command line:
-bash $0 ipaddr
-EOF
-        exit 1
-    fi
-fi
 declare p=2916
-declare install_server=http://$host:$p
+declare install_server=http://127.0.0.1:$p
 cat <<EOF
 In another shell, set the install_server:
 export install_server=$install_server
 
 Then run with function:
-radia_run unit-test arg1
+install_server=$install_server radia_run unit-test arg1
 
 or
 
-curl $install_server | bash -s unit-test arg1
+curl $install_server | install_server=$install_server bash -s unit-test arg1
 
 You can also pass "debug" to get more output:
 radia_run debug unit-test arg1


### PR DESCRIPTION
- token should not encoded in URL because ends up in repo git config
- added $no_install_main so install.sh can be used as library
- use 127.0.0.1 in doc for dev-server.sh