### PR TITLE
fix #871 TMAP8 

### DIFF
--- a/installers/rpm-code/codes.sh
+++ b/installers/rpm-code/codes.sh
@@ -326,6 +326,12 @@ codes_install() {
 
 }
 
+codes_install_file_from_stdin() {
+    declare tgt=$1
+    declare mode=${2:-555}
+    install_file_from_stdin "$mode" "$USER" "$(id -gn)" "$tgt"
+}
+
 codes_install_python_done() {
     declare pyenv_prefix=${1:-${codes_dir[pyenv_prefix]}}
     if [[ ! $pyenv_prefix ]]; then

--- a/installers/rpm-code/codes.sh
+++ b/installers/rpm-code/codes.sh
@@ -326,12 +326,6 @@ codes_install() {
 
 }
 
-codes_install_file_from_stdin() {
-    declare tgt=$1
-    declare mode=${2:-555}
-    install_file_from_stdin "$mode" "$USER" "$(id -gn)" "$tgt"
-}
-
 codes_install_python_done() {
     declare pyenv_prefix=${1:-${codes_dir[pyenv_prefix]}}
     if [[ ! $pyenv_prefix ]]; then

--- a/installers/rpm-code/codes/tmap8.sh
+++ b/installers/rpm-code/codes/tmap8.sh
@@ -3,7 +3,7 @@
 tmap8_main() {
     codes_yum_dependencies bison flex libtirpc-devel
     codes_dependencies common
-    codes_download idaholab/TMAP8 main
+    codes_download idaholab/TMAP8 ec0413009094eb9efc8c06e5133cd3f63621e051
     declare moose_dir=$PWD/moose
     declare petsc_prefix=${codes_dir[prefix]}/petsc
     declare libmesh_dir=${codes_dir[prefix]}/libmesh
@@ -27,6 +27,7 @@ tmap8_main() {
         -not -path "*/libmesh/*" \
         -name "*.so*" \
         -exec cp --no-dereference --preserve=links {} "$lib_dir/" \;
+    find "$lib_dir" -name "*.so*" ! -type l -exec strip --strip-unneeded {} \;
     # MOOSE and its modules look for data at <prefix>/share/<name>/data at runtime
     install -d -m 755 "${codes_dir[share]}/moose"
     cp -a "$moose_dir/framework/data" "${codes_dir[share]}/moose/"
@@ -36,6 +37,7 @@ tmap8_main() {
         install -d -m 755 "${codes_dir[share]}/$mod"
         cp -a "$d" "${codes_dir[share]}/$mod/"
     done
+    strip --strip-unneeded tmap8-opt
     install -m 555 tmap8-opt "${codes_dir[bin]}/tmap8-bin"
     # Wrapper so the binary finds its libs regardless of the build tree
     declare lp="${lib_dir}:${codes_dir[prefix]}/libmesh/lib:${codes_dir[prefix]}/petsc/lib"

--- a/installers/rpm-code/codes/tmap8.sh
+++ b/installers/rpm-code/codes/tmap8.sh
@@ -1,148 +1,57 @@
 #!/bin/bash
 
-tmap8_libmesh() {
-    declare moose_dir=$1
-    declare petsc_prefix=$2
-    declare libmesh_dir=$3
-    MOOSE_DIR=$moose_dir \
-    PETSC_DIR=$petsc_prefix \
-    LIBMESH_DIR=$libmesh_dir \
-    METHODS=opt \
-    MOOSE_JOBS=$(codes_num_cores) \
-        "$moose_dir"/scripts/update_and_rebuild_libmesh.sh \
-        --skip-submodule-update \
-        --disable-shared \
-        --enable-static \
-        --disable-netgen
-    # libmesh installs bin/ utility programs (meshtool, splitter, compare, etc.),
-    # examples/, contrib/, share/, and etc/ that TMAP8 never uses; with static
-    # PETSc/libmesh each utility separately embeds the full dependency tree
-    # (~400MB apiece). Nothing under libmesh_dir is needed at tmap8 runtime (it's
-    # fully statically linked), so keep only lib/ and include/ (needed below to
-    # compile/link TMAP8), plus two files moose/framework/build.mk shells out to
-    # while compiling TMAP8 itself: bin/libmesh-config (compiler/link flags) and
-    # contrib/bin/libtool (drives libtool-mode compilation of MOOSE's own .lo
-    # objects; build.mk checks this path before falling back to a top-level
-    # LIBMESH_DIR/libtool that libmesh's "make install" never actually creates).
-    # Verified against build.mk that no other LIBMESH_DIR paths are referenced.
-    find "$libmesh_dir" -mindepth 1 -maxdepth 1 -not -name lib -not -name include \
-         -not -name bin -not -name contrib -exec rm -rf {} +
-    find "$libmesh_dir/bin" -mindepth 1 -not -name libmesh-config -delete
-    find "$libmesh_dir/contrib" -mindepth 1 -not -path "*/contrib/bin" -not -name libtool -delete
-    # Static .a archives carry full debug/symbol info that shared libs would have
-    # dropped at link time; stripping is safe since only the global symbol table
-    # (needed for later linking) survives, not the archive index itself.
-    find "$petsc_prefix/lib" "$libmesh_dir/lib" -name "*.a" -exec strip --strip-unneeded {} \;
-    # Tutorial/example source trees, standalone PTScotch CLI tools, and other
-    # dev-only PETSc share/ content are not used by TMAP8 at build or run time.
-    rm -rf "$petsc_prefix/share/petsc/examples" "$petsc_prefix/share/petsc/datafiles" \
-       "$petsc_prefix/share/petsc/matlab" "$petsc_prefix/share/petsc/saws" \
-       "$petsc_prefix/share/petsc/xml" "$petsc_prefix/share/petsc/suppressions" \
-       "$petsc_prefix/share/slepc/examples" "$petsc_prefix/share/slepc/datafiles" \
-       "$petsc_prefix/share/man" "$petsc_prefix/bin"
+tmap8_build() {
+    PETSC_ARCH=arch-moose tmap8_update_and_rebuild petsc --with-shared-libraries=0
+    tmap8_update_and_rebuild wasp
+    tmap8_moose_python
+    METHODS=opt tmap8_update_and_rebuild libmesh --disable-shared --enable-static --disable-netgen
+    CPATH=$(codes_python_include_dir) METHOD=opt codes_make
+    tmap8_install
 }
 
 tmap8_main() {
     codes_yum_dependencies bison flex libtirpc-devel
     codes_dependencies common
+    declare tmp_d=$PWD/install
+    mkdir "$tmp_d"
     codes_download idaholab/TMAP8 ec0413009094eb9efc8c06e5133cd3f63621e051
-    declare moose_dir=$PWD/moose
-    declare petsc_prefix=${codes_dir[prefix]}/tmap8/petsc
-    declare libmesh_dir=${codes_dir[prefix]}/tmap8/libmesh
-    tmap8_petsc "$moose_dir" "$petsc_prefix"
-    tmap8_wasp "$moose_dir"
-    tmap8_moose_python "$moose_dir"
-    tmap8_libmesh "$moose_dir" "$petsc_prefix" "$libmesh_dir"
-    tmap8_make_tmap8 "$moose_dir" "$petsc_prefix" "$libmesh_dir"
-    sleep 100000
-    # Collect all MOOSE/TMAP8 shared libs from the build tree into codes_dir[lib]
-    # directly (flat, like libopenmc.so does), rather than a tmap8-only
-    # subdirectory; petsc and libmesh are already installed to their own
-    # prefixes.
-    declare lib_dir=${codes_dir[lib]}
-    find . \
-        -not -path "*/petsc/*" \
-        -not -path "*/libmesh/*" \
-        -name "*.so*" \
-        -exec cp --no-dereference --preserve=links {} "$lib_dir/" \;
-    find "$lib_dir" -name "*.so*" ! -type l -exec strip --strip-unneeded {} \;
-    # MOOSE and its modules look for data at <prefix>/share/<name>/data at runtime
-    install -d -m 755 "${codes_dir[share]}/moose"
-    cp -a "$moose_dir/framework/data" "${codes_dir[share]}/moose/"
-    find "$moose_dir/modules" -maxdepth 2 -name data -type d | while read -r d; do
-        declare mod
-        mod=$(basename "$(dirname "$d")")
-        install -d -m 755 "${codes_dir[share]}/$mod"
-        cp -a "$d" "${codes_dir[share]}/$mod/"
-    done
-    strip --strip-unneeded tmap8-opt
-    install -m 555 tmap8-opt "${codes_dir[bin]}/tmap8-bin"
-    # Wrapper so the binary finds its libs regardless of the build tree
-    install_file_from_stdin 555 vagrant vagrant "${codes_dir[bin]}/tmap8" <<EOF
-#!/bin/bash
-export LD_LIBRARY_PATH='$lib_dir:$petsc_prefix/lib'${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-exec '${codes_dir[bin]}'/tmap8-bin "\$@"
-EOF
+    declare d=$PWD/moose
+    hit_so=$d/framework/contrib/hit/hit.so \
+        LIBMESH_DIR=$tmp_d/tmap8/libmesh \
+        MOOSE_DIR=$d \
+        MOOOSE_JOBS=$(codes_num_cores) \
+        PETSC_DIR=$tmp_d/petsc \
+        PETSC_PREFIX=$tmp_d/petsc \
+        WASP_DIR=$tmp_d/wasp \
+        WASP_PREFIX=$tmp_d/wasp \
+        tmap8_build
 }
 
-tmap8_make_tmap8() {
-    declare moose_dir=$1
-    declare petsc_prefix=$2
-    declare libmesh_dir=$3
-    # python3-config --includes returns the virtualenv include dir whose headers are
-    # symlinks; those symlinks are broken in the container RPM install. Point CPATH
-    # at the base Python include dir (real files) so GCC always finds Python.h.
-    # codes_python_include_dir gives the same base path (verified: unlike
-    # python3-config, distutils.sysconfig.get_python_inc() isn't venv-relative).
-    CPATH=$(codes_python_include_dir) \
-    MOOSE_DIR=$moose_dir PETSC_DIR=$petsc_prefix LIBMESH_DIR=$libmesh_dir METHOD=opt \
-        codes_make
-    # Headers/archives are only needed to compile/link against petsc; nothing in
-    # the installed RPM (or at tmap8/moose-python runtime) needs them once
-    # tmap8-opt is linked. In fact nothing under petsc_prefix is needed at
-    # runtime except lib/libceed.so (verified empirically: tmap8 runs identically
-    # with everything else removed): libCEED's own build never produces a static
-    # libceed.a (see tmap8_petsc's --with-shared-libraries=0 comment), so it's
-    # the one piece PETSc ends up linking dynamically instead of embedding like
-    # everything else. Neither moose's python tools (pyhit/mooseutils/mms) nor
-    # tmap8-opt reference any other petsc_prefix path.
-    find "$petsc_prefix" -mindepth 1 -maxdepth 1 -not -name lib -exec rm -rf {} +
-    find "$petsc_prefix/lib" -mindepth 1 -not -name libceed.so -delete
-    # libmesh is fully statically linked with no runtime data of its own (verified
-    # empirically: tmap8 runs identically with libmesh_dir removed entirely), so
-    # nothing under it is needed once tmap8-opt is linked.
-    rm -rf "$libmesh_dir"
+tmap8_install() {
+    install -m 555 \
+        "$PETSC_PREFIX"/lib/libceed.so \
+        "$WASP_PREFIX"/lib/libwasp*.{so,so.*} \
+        "$hit_so" \
+        "${codes_dir[lib]}"
+    install -m 555 tmap8-opt "${codes_dir[bin]}"/tmap8
 }
 
 tmap8_moose_python() {
-    declare moose_dir=$1
-    declare hit_src=$moose_dir/framework/contrib/hit
     # build hit.so (Cython binding to the WASP HIT parser) needed by pyhit
-    declare dest=$(codes_python_lib_dir)/
-    CPATH=$dest make -C "$hit_src" -j"$(codes_num_cores)" bindings
+    declare dest=
+    CPATH=$(codes_python_include_dir) make -C "$(dirname "$hit_so")" -j"$(codes_num_cores)" bindings
     # `import hit` relies on LD_LIBRARY_PATH including
     # codes_dir[lib] to find the WASP libs it's linked against.
-    chmod -R a+rX "$moose_dir"/python/ "$hit_src/hit.so"
-    cp -a "$moose_dir"/python/{moosetree,mooseutils,mms} "$hit_src/hit.so" "$dest"
+    chmod -R a+rX "$MOOSE_DIR"/python/ "$hit_so"
+    cp -a "$MOOSE_DIR"/python/{moosetree,mooseutils,mms} "$hit_so" "$(codes_python_lib_dir)/"
+    # avoids Failed to determine data file path for 'moose' & solid_mechanics
+    install -d -m 755 "${codes_dir[share]}"/{solid_mechanics,moose}{,/data}
 }
 
-tmap8_petsc() {
-    declare moose_dir=$1
-    declare petsc_prefix=$2
-    MOOSE_DIR=$moose_dir \
-    PETSC_DIR=$moose_dir/petsc \
-    PETSC_ARCH=arch-moose \
-    PETSC_PREFIX=$petsc_prefix \
-    MOOSE_JOBS=$(codes_num_cores) \
-        "$moose_dir"/scripts/update_and_rebuild_petsc.sh \
+tmap8_update_and_rebuild() {
+    declare which=$1
+    shift
+    "$MOOSE_DIR"/scripts/update_and_rebuild_$which.sh \
         --skip-submodule-update \
-        --with-shared-libraries=0
-}
-
-tmap8_wasp() {
-    declare moose_dir=$1
-    MOOSE_DIR=$moose_dir \
-    MOOSE_JOBS=$(codes_num_cores) \
-        "$moose_dir"/scripts/update_and_rebuild_wasp.sh \
-        --skip-submodule-update
+        "$@"
 }

--- a/installers/rpm-code/codes/tmap8.sh
+++ b/installers/rpm-code/codes/tmap8.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 
-tmap8_main() {
-    codes_yum_dependencies bison flex libtirpc-devel
-    codes_dependencies common
-    codes_download idaholab/TMAP8 ec0413009094eb9efc8c06e5133cd3f63621e051
-    declare moose_dir=$PWD/moose
-    declare petsc_prefix=${codes_dir[prefix]}/tmap8/petsc
-    declare libmesh_dir=${codes_dir[prefix]}/tmap8/libmesh
-    tmap8_petsc "$moose_dir" "$petsc_prefix"
-    tmap8_wasp "$moose_dir"
-    tmap8_moose_python "$moose_dir"
-    tmap8_libmesh "$moose_dir" "$petsc_prefix" "$libmesh_dir"
+tmap8_libmesh() {
+    declare moose_dir=$1
+    declare petsc_prefix=$2
+    declare libmesh_dir=$3
+    MOOSE_DIR=$moose_dir \
+    PETSC_DIR=$petsc_prefix \
+    LIBMESH_DIR=$libmesh_dir \
+    METHODS=opt \
+    MOOSE_JOBS=$(codes_num_cores) \
+        "$moose_dir"/scripts/update_and_rebuild_libmesh.sh \
+        --skip-submodule-update \
+        --disable-shared \
+        --enable-static \
+        --disable-netgen
     # libmesh installs bin/ utility programs (meshtool, splitter, compare, etc.),
     # examples/, contrib/, share/, and etc/ that TMAP8 never uses; with static
     # PETSc/libmesh each utility separately embeds the full dependency tree
@@ -23,7 +26,7 @@ tmap8_main() {
     # LIBMESH_DIR/libtool that libmesh's "make install" never actually creates).
     # Verified against build.mk that no other LIBMESH_DIR paths are referenced.
     find "$libmesh_dir" -mindepth 1 -maxdepth 1 -not -name lib -not -name include \
-        -not -name bin -not -name contrib -exec rm -rf {} +
+         -not -name bin -not -name contrib -exec rm -rf {} +
     find "$libmesh_dir/bin" -mindepth 1 -not -name libmesh-config -delete
     find "$libmesh_dir/contrib" -mindepth 1 -not -path "*/contrib/bin" -not -name libtool -delete
     # Static .a archives carry full debug/symbol info that shared libs would have
@@ -33,10 +36,59 @@ tmap8_main() {
     # Tutorial/example source trees, standalone PTScotch CLI tools, and other
     # dev-only PETSc share/ content are not used by TMAP8 at build or run time.
     rm -rf "$petsc_prefix/share/petsc/examples" "$petsc_prefix/share/petsc/datafiles" \
-        "$petsc_prefix/share/petsc/matlab" "$petsc_prefix/share/petsc/saws" \
-        "$petsc_prefix/share/petsc/xml" "$petsc_prefix/share/petsc/suppressions" \
-        "$petsc_prefix/share/slepc/examples" "$petsc_prefix/share/slepc/datafiles" \
-        "$petsc_prefix/share/man" "$petsc_prefix/bin"
+       "$petsc_prefix/share/petsc/matlab" "$petsc_prefix/share/petsc/saws" \
+       "$petsc_prefix/share/petsc/xml" "$petsc_prefix/share/petsc/suppressions" \
+       "$petsc_prefix/share/slepc/examples" "$petsc_prefix/share/slepc/datafiles" \
+       "$petsc_prefix/share/man" "$petsc_prefix/bin"
+}
+
+tmap8_main() {
+    codes_yum_dependencies bison flex libtirpc-devel
+    codes_dependencies common
+    codes_download idaholab/TMAP8 ec0413009094eb9efc8c06e5133cd3f63621e051
+    declare moose_dir=$PWD/moose
+    declare petsc_prefix=${codes_dir[prefix]}/tmap8/petsc
+    declare libmesh_dir=${codes_dir[prefix]}/tmap8/libmesh
+    tmap8_petsc "$moose_dir" "$petsc_prefix"
+    tmap8_wasp "$moose_dir"
+    tmap8_moose_python "$moose_dir"
+    tmap8_libmesh "$moose_dir" "$petsc_prefix" "$libmesh_dir"
+    tmap8_make_tmap8 "$moose_dir" "$petsc_prefix" "$libmesh_dir"
+    sleep 100000
+    # Collect all MOOSE/TMAP8 shared libs from the build tree into codes_dir[lib]
+    # directly (flat, like libopenmc.so does), rather than a tmap8-only
+    # subdirectory; petsc and libmesh are already installed to their own
+    # prefixes.
+    declare lib_dir=${codes_dir[lib]}
+    find . \
+        -not -path "*/petsc/*" \
+        -not -path "*/libmesh/*" \
+        -name "*.so*" \
+        -exec cp --no-dereference --preserve=links {} "$lib_dir/" \;
+    find "$lib_dir" -name "*.so*" ! -type l -exec strip --strip-unneeded {} \;
+    # MOOSE and its modules look for data at <prefix>/share/<name>/data at runtime
+    install -d -m 755 "${codes_dir[share]}/moose"
+    cp -a "$moose_dir/framework/data" "${codes_dir[share]}/moose/"
+    find "$moose_dir/modules" -maxdepth 2 -name data -type d | while read -r d; do
+        declare mod
+        mod=$(basename "$(dirname "$d")")
+        install -d -m 755 "${codes_dir[share]}/$mod"
+        cp -a "$d" "${codes_dir[share]}/$mod/"
+    done
+    strip --strip-unneeded tmap8-opt
+    install -m 555 tmap8-opt "${codes_dir[bin]}/tmap8-bin"
+    # Wrapper so the binary finds its libs regardless of the build tree
+    install_file_from_stdin 555 vagrant vagrant "${codes_dir[bin]}/tmap8" <<EOF
+#!/bin/bash
+export LD_LIBRARY_PATH='$lib_dir:$petsc_prefix/lib'${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+exec '${codes_dir[bin]}'/tmap8-bin "\$@"
+EOF
+}
+
+tmap8_make_tmap8() {
+    declare moose_dir=$1
+    declare petsc_prefix=$2
+    declare libmesh_dir=$3
     # python3-config --includes returns the virtualenv include dir whose headers are
     # symlinks; those symlinks are broken in the container RPM install. Point CPATH
     # at the base Python include dir (real files) so GCC always finds Python.h.
@@ -60,76 +112,23 @@ tmap8_main() {
     # empirically: tmap8 runs identically with libmesh_dir removed entirely), so
     # nothing under it is needed once tmap8-opt is linked.
     rm -rf "$libmesh_dir"
-    # Collect all MOOSE/TMAP8 shared libs from the build tree into codes_dir[lib]
-    # directly (flat, like libopenmc.so does), rather than a tmap8-only
-    # subdirectory; petsc and libmesh are already installed to their own
-    # prefixes.
-    declare lib_dir=${codes_dir[lib]}
-    mkdir -p "$lib_dir"
-    find . \
-        -not -path "*/petsc/*" \
-        -not -path "*/libmesh/*" \
-        -name "*.so*" \
-        -exec cp --no-dereference --preserve=links {} "$lib_dir/" \;
-    find "$lib_dir" -name "*.so*" ! -type l -exec strip --strip-unneeded {} \;
-    # MOOSE and its modules look for data at <prefix>/share/<name>/data at runtime
-    install -d -m 755 "${codes_dir[share]}/moose"
-    cp -a "$moose_dir/framework/data" "${codes_dir[share]}/moose/"
-    find "$moose_dir/modules" -maxdepth 2 -name data -type d | while read -r d; do
-        declare mod
-        mod=$(basename "$(dirname "$d")")
-        install -d -m 755 "${codes_dir[share]}/$mod"
-        cp -a "$d" "${codes_dir[share]}/$mod/"
-    done
-    strip --strip-unneeded tmap8-opt
-    install -m 555 tmap8-opt "${codes_dir[bin]}/tmap8-bin"
-    # Wrapper so the binary finds its libs regardless of the build tree
-    install_file_from_stdin 555 vagrant vagrant "${codes_dir[bin]}/tmap8" <<EOF
-#!/bin/bash
-export LD_LIBRARY_PATH="$lib_dir:$petsc_prefix/lib\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH:-}"
-exec "${codes_dir[bin]}/tmap8-bin" "\$@"
-EOF
 }
 
 tmap8_moose_python() {
     declare moose_dir=$1
     declare hit_src=$moose_dir/framework/contrib/hit
     # build hit.so (Cython binding to the WASP HIT parser) needed by pyhit
-    CPATH=$(codes_python_include_dir) \
-        make -C "$hit_src" -j"$(codes_num_cores)" bindings
-    # `import hit` (pyhit does this) relies on LD_LIBRARY_PATH including
+    declare dest=$(codes_python_lib_dir)/
+    CPATH=$dest make -C "$hit_src" -j"$(codes_num_cores)" bindings
+    # `import hit` relies on LD_LIBRARY_PATH including
     # codes_dir[lib] to find the WASP libs it's linked against.
-    for pkg in pyhit moosetree mooseutils mms; do
-        cp -r "$moose_dir/python/$pkg" "$(codes_python_lib_dir)/"
-    done
-    # hit.so must be importable as a top-level module (pyhit does `import hit`)
-    install -m 555 "$hit_src/hit.so" "$(codes_python_lib_dir)/"
-}
-
-tmap8_wasp() {
-    declare moose_dir=$1
-    MOOSE_DIR=$moose_dir \
-    MOOSE_JOBS=$(codes_num_cores) \
-        "$moose_dir"/scripts/update_and_rebuild_wasp.sh \
-        --skip-submodule-update
-}
-
-tmap8_libmesh() {
-    declare moose_dir=$1 petsc_prefix=$2 libmesh_dir=$3
-    MOOSE_DIR=$moose_dir \
-    PETSC_DIR=$petsc_prefix \
-    LIBMESH_DIR=$libmesh_dir \
-    METHODS=opt \
-    MOOSE_JOBS=$(codes_num_cores) \
-        "$moose_dir"/scripts/update_and_rebuild_libmesh.sh \
-        --skip-submodule-update \
-        --disable-shared \
-        --enable-static \
-        --disable-netgen
+    chmod -R a+rX "$moose_dir"/python/ "$hit_src/hit.so"
+    cp -a "$moose_dir"/python/{moosetree,mooseutils,mms} "$hit_src/hit.so" "$dest"
 }
 
 tmap8_petsc() {
-    declare moose_dir=$1 petsc_prefix=$2
+    declare moose_dir=$1
+    declare petsc_prefix=$2
     MOOSE_DIR=$moose_dir \
     PETSC_DIR=$moose_dir/petsc \
     PETSC_ARCH=arch-moose \
@@ -138,4 +137,12 @@ tmap8_petsc() {
         "$moose_dir"/scripts/update_and_rebuild_petsc.sh \
         --skip-submodule-update \
         --with-shared-libraries=0
+}
+
+tmap8_wasp() {
+    declare moose_dir=$1
+    MOOSE_DIR=$moose_dir \
+    MOOSE_JOBS=$(codes_num_cores) \
+        "$moose_dir"/scripts/update_and_rebuild_wasp.sh \
+        --skip-submodule-update
 }

--- a/installers/rpm-code/codes/tmap8.sh
+++ b/installers/rpm-code/codes/tmap8.sh
@@ -11,6 +11,32 @@ tmap8_main() {
     tmap8_wasp "$moose_dir"
     tmap8_moose_python "$moose_dir"
     tmap8_libmesh "$moose_dir" "$petsc_prefix" "$libmesh_dir"
+    # libmesh installs bin/ utility programs (meshtool, splitter, compare, etc.),
+    # examples/, contrib/, share/, and etc/ that TMAP8 never uses; with static
+    # PETSc/libmesh each utility separately embeds the full dependency tree
+    # (~400MB apiece). Nothing under libmesh_dir is needed at tmap8 runtime (it's
+    # fully statically linked), so keep only lib/ and include/ (needed below to
+    # compile/link TMAP8), plus two files moose/framework/build.mk shells out to
+    # while compiling TMAP8 itself: bin/libmesh-config (compiler/link flags) and
+    # contrib/bin/libtool (drives libtool-mode compilation of MOOSE's own .lo
+    # objects; build.mk checks this path before falling back to a top-level
+    # LIBMESH_DIR/libtool that libmesh's "make install" never actually creates).
+    # Verified against build.mk that no other LIBMESH_DIR paths are referenced.
+    find "$libmesh_dir" -mindepth 1 -maxdepth 1 -not -name lib -not -name include \
+        -not -name bin -not -name contrib -exec rm -rf {} +
+    find "$libmesh_dir/bin" -mindepth 1 -not -name libmesh-config -delete
+    find "$libmesh_dir/contrib" -mindepth 1 -not -path "*/contrib/bin" -not -name libtool -delete
+    # Static .a archives carry full debug/symbol info that shared libs would have
+    # dropped at link time; stripping is safe since only the global symbol table
+    # (needed for later linking) survives, not the archive index itself.
+    find "$petsc_prefix/lib" "$libmesh_dir/lib" -name "*.a" -exec strip --strip-unneeded {} \;
+    # Tutorial/example source trees, standalone PTScotch CLI tools, and other
+    # dev-only PETSc share/ content are not used by TMAP8 at build or run time.
+    rm -rf "$petsc_prefix/share/petsc/examples" "$petsc_prefix/share/petsc/datafiles" \
+        "$petsc_prefix/share/petsc/matlab" "$petsc_prefix/share/petsc/saws" \
+        "$petsc_prefix/share/petsc/xml" "$petsc_prefix/share/petsc/suppressions" \
+        "$petsc_prefix/share/slepc/examples" "$petsc_prefix/share/slepc/datafiles" \
+        "$petsc_prefix/share/man" "$petsc_prefix/bin"
     # python3-config --includes returns the virtualenv include dir whose headers are
     # symlinks; those symlinks are broken in the container RPM install. Point CPATH
     # at the base Python include dir (real files) so GCC always finds Python.h.
@@ -19,6 +45,21 @@ tmap8_main() {
     CPATH=$python_inc \
     MOOSE_DIR=$moose_dir PETSC_DIR=$petsc_prefix LIBMESH_DIR=$libmesh_dir METHOD=opt \
         codes_make
+    # Headers/archives are only needed to compile/link against petsc; nothing in
+    # the installed RPM (or at tmap8/moose-python runtime) needs them once
+    # tmap8-opt is linked. In fact nothing under petsc_prefix is needed at
+    # runtime except lib/libceed.so (verified empirically: tmap8 runs identically
+    # with everything else removed): libCEED's own build never produces a static
+    # libceed.a (see tmap8_petsc's --with-shared-libraries=0 comment), so it's
+    # the one piece PETSc ends up linking dynamically instead of embedding like
+    # everything else. Neither moose's python tools (pyhit/mooseutils/mms) nor
+    # tmap8-opt reference any other petsc_prefix path.
+    find "$petsc_prefix" -mindepth 1 -maxdepth 1 -not -name lib -exec rm -rf {} +
+    find "$petsc_prefix/lib" -mindepth 1 -not -name libceed.so -delete
+    # libmesh is fully statically linked with no runtime data of its own (verified
+    # empirically: tmap8 runs identically with libmesh_dir removed entirely), so
+    # nothing under it is needed once tmap8-opt is linked.
+    rm -rf "$libmesh_dir"
     # Collect all MOOSE/TMAP8 shared libs from the build tree into a single
     # directory; petsc and libmesh are already installed to their own prefixes.
     declare lib_dir=${codes_dir[lib]}/tmap8
@@ -41,7 +82,7 @@ tmap8_main() {
     strip --strip-unneeded tmap8-opt
     install -m 555 tmap8-opt "${codes_dir[bin]}/tmap8-bin"
     # Wrapper so the binary finds its libs regardless of the build tree
-    declare lp="${lib_dir}:${codes_dir[prefix]}/libmesh/lib:${codes_dir[prefix]}/petsc/lib"
+    declare lp="${lib_dir}:${codes_dir[prefix]}/petsc/lib"
     install -m 555 /dev/stdin "${codes_dir[bin]}/tmap8" <<EOF
 #!/bin/bash
 export LD_LIBRARY_PATH="${lp}\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH:-}"
@@ -85,7 +126,10 @@ tmap8_libmesh() {
     METHODS=opt \
     MOOSE_JOBS=$(codes_num_cores) \
         "$moose_dir"/scripts/update_and_rebuild_libmesh.sh \
-        --skip-submodule-update
+        --skip-submodule-update \
+        --disable-shared \
+        --enable-static \
+        --disable-netgen
 }
 
 tmap8_petsc() {
@@ -96,5 +140,6 @@ tmap8_petsc() {
     PETSC_PREFIX=$petsc_prefix \
     MOOSE_JOBS=$(codes_num_cores) \
         "$moose_dir"/scripts/update_and_rebuild_petsc.sh \
-        --skip-submodule-update
+        --skip-submodule-update \
+        --with-shared-libraries=0
 }

--- a/installers/rpm-code/codes/tmap8.sh
+++ b/installers/rpm-code/codes/tmap8.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 tmap8_main() {
-    codes_yum_dependencies bison flex libtirpc-devel
+    codes_yum_dependencies bison flex libtirpc-devel patchelf
     codes_dependencies common
     codes_download idaholab/TMAP8 ec0413009094eb9efc8c06e5133cd3f63621e051
     declare moose_dir=$PWD/moose
@@ -9,6 +9,7 @@ tmap8_main() {
     declare libmesh_dir=${codes_dir[prefix]}/libmesh
     tmap8_petsc "$moose_dir" "$petsc_prefix"
     tmap8_wasp "$moose_dir"
+    tmap8_moose_python "$moose_dir"
     tmap8_libmesh "$moose_dir" "$petsc_prefix" "$libmesh_dir"
     # python3-config --includes returns the virtualenv include dir whose headers are
     # symlinks; those symlinks are broken in the container RPM install. Point CPATH
@@ -46,6 +47,26 @@ tmap8_main() {
 export LD_LIBRARY_PATH="${lp}\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH:-}"
 exec "${codes_dir[bin]}/tmap8-bin" "\$@"
 EOF
+}
+
+tmap8_moose_python() {
+    declare moose_dir=$1
+    declare hit_src=$moose_dir/framework/contrib/hit
+    declare python_inc
+    python_inc=$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))')
+    # build hit.so (Cython binding to the WASP HIT parser) needed by pyhit
+    CPATH=$python_inc \
+        make -C "$hit_src" -j"$(codes_num_cores)" bindings
+    # rewrite build-tree RUNPATH to the installed WASP lib dir so pyhit
+    # works without LD_LIBRARY_PATH after the RPM is deployed
+    patchelf --set-rpath "${codes_dir[lib]}/tmap8" "$hit_src/hit.so"
+    declare site
+    site=$(codes_python_lib_dir)
+    for pkg in pyhit moosetree mooseutils mms; do
+        cp -r "$moose_dir/python/$pkg" "$site/"
+    done
+    # hit.so must be importable as a top-level module (pyhit does `import hit`)
+    install -m 755 "$hit_src/hit.so" "$site/"
 }
 
 tmap8_wasp() {

--- a/installers/rpm-code/codes/tmap8.sh
+++ b/installers/rpm-code/codes/tmap8.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 tmap8_main() {
-    codes_yum_dependencies bison flex libtirpc-devel patchelf
+    codes_yum_dependencies bison flex libtirpc-devel
     codes_dependencies common
     codes_download idaholab/TMAP8 ec0413009094eb9efc8c06e5133cd3f63621e051
     declare moose_dir=$PWD/moose
-    declare petsc_prefix=${codes_dir[prefix]}/petsc
-    declare libmesh_dir=${codes_dir[prefix]}/libmesh
+    declare petsc_prefix=${codes_dir[prefix]}/tmap8/petsc
+    declare libmesh_dir=${codes_dir[prefix]}/tmap8/libmesh
     tmap8_petsc "$moose_dir" "$petsc_prefix"
     tmap8_wasp "$moose_dir"
     tmap8_moose_python "$moose_dir"
@@ -40,9 +40,9 @@ tmap8_main() {
     # python3-config --includes returns the virtualenv include dir whose headers are
     # symlinks; those symlinks are broken in the container RPM install. Point CPATH
     # at the base Python include dir (real files) so GCC always finds Python.h.
-    declare python_inc
-    python_inc=$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))')
-    CPATH=$python_inc \
+    # codes_python_include_dir gives the same base path (verified: unlike
+    # python3-config, distutils.sysconfig.get_python_inc() isn't venv-relative).
+    CPATH=$(codes_python_include_dir) \
     MOOSE_DIR=$moose_dir PETSC_DIR=$petsc_prefix LIBMESH_DIR=$libmesh_dir METHOD=opt \
         codes_make
     # Headers/archives are only needed to compile/link against petsc; nothing in
@@ -60,9 +60,11 @@ tmap8_main() {
     # empirically: tmap8 runs identically with libmesh_dir removed entirely), so
     # nothing under it is needed once tmap8-opt is linked.
     rm -rf "$libmesh_dir"
-    # Collect all MOOSE/TMAP8 shared libs from the build tree into a single
-    # directory; petsc and libmesh are already installed to their own prefixes.
-    declare lib_dir=${codes_dir[lib]}/tmap8
+    # Collect all MOOSE/TMAP8 shared libs from the build tree into codes_dir[lib]
+    # directly (flat, like libopenmc.so does), rather than a tmap8-only
+    # subdirectory; petsc and libmesh are already installed to their own
+    # prefixes.
+    declare lib_dir=${codes_dir[lib]}
     mkdir -p "$lib_dir"
     find . \
         -not -path "*/petsc/*" \
@@ -82,10 +84,9 @@ tmap8_main() {
     strip --strip-unneeded tmap8-opt
     install -m 555 tmap8-opt "${codes_dir[bin]}/tmap8-bin"
     # Wrapper so the binary finds its libs regardless of the build tree
-    declare lp="${lib_dir}:${codes_dir[prefix]}/petsc/lib"
-    install -m 555 /dev/stdin "${codes_dir[bin]}/tmap8" <<EOF
+    install_file_from_stdin 555 vagrant vagrant "${codes_dir[bin]}/tmap8" <<EOF
 #!/bin/bash
-export LD_LIBRARY_PATH="${lp}\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH="$lib_dir:$petsc_prefix/lib\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH:-}"
 exec "${codes_dir[bin]}/tmap8-bin" "\$@"
 EOF
 }
@@ -93,21 +94,16 @@ EOF
 tmap8_moose_python() {
     declare moose_dir=$1
     declare hit_src=$moose_dir/framework/contrib/hit
-    declare python_inc
-    python_inc=$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))')
     # build hit.so (Cython binding to the WASP HIT parser) needed by pyhit
-    CPATH=$python_inc \
+    CPATH=$(codes_python_include_dir) \
         make -C "$hit_src" -j"$(codes_num_cores)" bindings
-    # rewrite build-tree RUNPATH to the installed WASP lib dir so pyhit
-    # works without LD_LIBRARY_PATH after the RPM is deployed
-    patchelf --set-rpath "${codes_dir[lib]}/tmap8" "$hit_src/hit.so"
-    declare site
-    site=$(codes_python_lib_dir)
+    # `import hit` (pyhit does this) relies on LD_LIBRARY_PATH including
+    # codes_dir[lib] to find the WASP libs it's linked against.
     for pkg in pyhit moosetree mooseutils mms; do
-        cp -r "$moose_dir/python/$pkg" "$site/"
+        cp -r "$moose_dir/python/$pkg" "$(codes_python_lib_dir)/"
     done
     # hit.so must be importable as a top-level module (pyhit does `import hit`)
-    install -m 755 "$hit_src/hit.so" "$site/"
+    install -m 555 "$hit_src/hit.so" "$(codes_python_lib_dir)/"
 }
 
 tmap8_wasp() {

--- a/installers/rpm-code/codes/tmap8.sh
+++ b/installers/rpm-code/codes/tmap8.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+tmap8_main() {
+    codes_yum_dependencies bison flex libtirpc-devel python3-devel
+    codes_dependencies common
+    codes_download idaholab/TMAP8 main
+    declare moose_dir=$PWD/moose
+    declare petsc_prefix=${codes_dir[prefix]}/petsc
+    declare libmesh_dir=${codes_dir[prefix]}/libmesh
+    tmap8_petsc "$moose_dir" "$petsc_prefix"
+    tmap8_wasp "$moose_dir"
+    tmap8_libmesh "$moose_dir" "$petsc_prefix" "$libmesh_dir"
+    # python3-config --includes returns the virtualenv include dir whose headers are
+    # symlinks; those symlinks are broken in the container RPM install. Point CPATH
+    # at the base Python include dir (real files) so GCC always finds Python.h.
+    declare python_inc
+    python_inc=$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))')
+    CPATH=$python_inc \
+    MOOSE_DIR=$moose_dir PETSC_DIR=$petsc_prefix LIBMESH_DIR=$libmesh_dir METHOD=opt \
+        codes_make
+    # Collect all MOOSE/TMAP8 shared libs from the build tree into a single
+    # directory; petsc and libmesh are already installed to their own prefixes.
+    declare lib_dir=${codes_dir[lib]}/tmap8
+    mkdir -p "$lib_dir"
+    find . \
+        -not -path "*/petsc/*" \
+        -not -path "*/libmesh/*" \
+        -name "*.so*" \
+        -exec cp --no-dereference --preserve=links {} "$lib_dir/" \;
+    # MOOSE and its modules look for data at <prefix>/share/<name>/data at runtime
+    install -d -m 755 "${codes_dir[share]}/moose"
+    cp -a "$moose_dir/framework/data" "${codes_dir[share]}/moose/"
+    find "$moose_dir/modules" -maxdepth 2 -name data -type d | while read -r d; do
+        declare mod
+        mod=$(basename "$(dirname "$d")")
+        install -d -m 755 "${codes_dir[share]}/$mod"
+        cp -a "$d" "${codes_dir[share]}/$mod/"
+    done
+    install -m 555 tmap8-opt "${codes_dir[bin]}/tmap8-bin"
+    # Wrapper so the binary finds its libs regardless of the build tree
+    declare lp="${lib_dir}:${codes_dir[prefix]}/libmesh/lib:${codes_dir[prefix]}/petsc/lib"
+    install -m 555 /dev/stdin "${codes_dir[bin]}/tmap8" <<EOF
+#!/bin/bash
+export LD_LIBRARY_PATH="${lp}\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH:-}"
+exec "${codes_dir[bin]}/tmap8-bin" "\$@"
+EOF
+}
+
+tmap8_wasp() {
+    declare moose_dir=$1
+    MOOSE_DIR=$moose_dir \
+    MOOSE_JOBS=$(codes_num_cores) \
+        "$moose_dir"/scripts/update_and_rebuild_wasp.sh \
+        --skip-submodule-update
+}
+
+tmap8_libmesh() {
+    declare moose_dir=$1 petsc_prefix=$2 libmesh_dir=$3
+    MOOSE_DIR=$moose_dir \
+    PETSC_DIR=$petsc_prefix \
+    LIBMESH_DIR=$libmesh_dir \
+    METHODS=opt \
+    MOOSE_JOBS=$(codes_num_cores) \
+        "$moose_dir"/scripts/update_and_rebuild_libmesh.sh \
+        --skip-submodule-update
+}
+
+tmap8_petsc() {
+    declare moose_dir=$1 petsc_prefix=$2
+    MOOSE_DIR=$moose_dir \
+    PETSC_DIR=$moose_dir/petsc \
+    PETSC_ARCH=arch-moose \
+    PETSC_PREFIX=$petsc_prefix \
+    MOOSE_JOBS=$(codes_num_cores) \
+        "$moose_dir"/scripts/update_and_rebuild_petsc.sh \
+        --skip-submodule-update
+}

--- a/installers/rpm-code/codes/tmap8.sh
+++ b/installers/rpm-code/codes/tmap8.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 tmap8_main() {
-    codes_yum_dependencies bison flex libtirpc-devel python3-devel
+    codes_yum_dependencies bison flex libtirpc-devel
     codes_dependencies common
     codes_download idaholab/TMAP8 main
     declare moose_dir=$PWD/moose


### PR DESCRIPTION
This script creates a runnable tmap8 executable. It takes over an hour to build.

The rpm is 295M. Could be reduced by removing symbols?

The build creates sub builds of libmesh and petsc. These don't conflict with the other rpms because they are in ~/.local/libmesh and ~/.local/petsc.  We could try to get the petsc requirements directly into petsc.sh instead?

The TMAP8 repo does not have tags so we should lock down to a specific git commit, rather than the top of main which it is currently using.

A minimal tmap8 test case:

$ tmap8 -i test.i

```
# test.i
diffusivity = 1.0
thickness = 200.0

[Mesh]
  type = GeneratedMesh
  dim = 1
  nx = 10
  xmax = ${thickness}
[]

[Variables]
  [u]
  []
[]

[Kernels]
  [diff]
    type = MatDiffusion
    variable = u
    diffusivity = ${diffusivity}
  []
  [time]
    type = TimeDerivative
    variable = u
  []
[]

[BCs]
  [left]
    type = DirichletBC
    variable = u
    boundary = left
    value = 1
  []
  [right]
    type = DirichletBC
    variable = u
    boundary = right
    value = 0
  []
[]

[Postprocessors]
  [mid_conc]
    type = PointValue
    variable = u
    point = '1 0 0'
    outputs = csv
  []
[]

[Executioner]
  type = Transient
  end_time = 5
  dt = 1
  solve_type = NEWTON
  petsc_options_iname = '-pc_type'
  petsc_options_value = 'lu'
[]

[Outputs]
  file_base = tmap8_test_out
  [csv]
    type = CSV
    execute_on = 'INITIAL TIMESTEP_END'
  []
[]
```

should produce a csv with output:
```
time,mid_conc
0,0
1,0.9369461717326
2,0.9372854335141
3,0.9376203995413
4,0.93795114219532
5,0.93827773245105
```

