### PR TITLE
Fix #896 replace `install_version_centos` with more accurate name `install_version_rhel`

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -314,7 +314,7 @@ install_init_vars_versions() {
         install_err 'unable to determine operating system version'
     fi
     : ${install_version_fedora:=43}
-    : ${install_version_centos:=7}
+    : ${install_version_rhel:=7}
     if [[ ! ${install_version_python:-} ]]; then
         if install_os_is_centos_7; then
             install_version_python=3.9.15
@@ -629,7 +629,7 @@ install_vars_export() {
         install_proprietary_key
         install_version_fedora
         install_version_python
-        install_version_centos
+        install_version_rhel
         $(compgen -A variable RADIA_RUN_)
         $(compgen -A variable GITHUB_)
     )

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -314,8 +314,7 @@ install_init_vars_versions() {
         install_err 'unable to determine operating system version'
     fi
     : ${install_version_fedora:=43}
-    : ${install_version_centos:=7}
-    : ${install_version_rhel:=7}
+    install_init_vars_rhel
     if [[ ! ${install_version_python:-} ]]; then
         if install_os_is_centos_7; then
             install_version_python=3.9.15
@@ -324,6 +323,15 @@ install_init_vars_versions() {
         fi
     fi
     : ${install_version_python_venv:=py${install_version_python%%.*}}
+}
+
+install_init_vars_rhel() {
+    if ! [[ ${install_version_rhel:-} || ${install_version_centos:-} ]]; then
+        install_version_rhel=7
+    elif [[ ${install_version_centos:-} ]]; then
+        # Backward compatibility
+        install_version_rhel=$install_version_centos
+    fi
 }
 
 install_init_vars_servers() {
@@ -630,7 +638,6 @@ install_vars_export() {
         install_proprietary_key
         install_version_fedora
         install_version_python
-        install_version_centos
         install_version_rhel
         $(compgen -A variable RADIA_RUN_)
         $(compgen -A variable GITHUB_)

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -326,11 +326,13 @@ install_init_vars_versions() {
 }
 
 install_init_vars_rhel() {
-    if ! [[ ${install_version_rhel:-} || ${install_version_centos:-} ]]; then
-        install_version_rhel=7
+    if [[ ${install_version_rhel:-} ]]; then
+        install_version_centos=$install_version_rhel
     elif [[ ${install_version_centos:-} ]]; then
-        # Backward compatibility
         install_version_rhel=$install_version_centos
+    else
+        install_version_rhel=7
+        install_version_centos=$install_version_rhel
     fi
 }
 
@@ -638,6 +640,7 @@ install_vars_export() {
         install_proprietary_key
         install_version_fedora
         install_version_python
+        install_version_centos
         install_version_rhel
         $(compgen -A variable RADIA_RUN_)
         $(compgen -A variable GITHUB_)

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -314,6 +314,7 @@ install_init_vars_versions() {
         install_err 'unable to determine operating system version'
     fi
     : ${install_version_fedora:=43}
+    : ${install_version_centos:=7}
     : ${install_version_rhel:=7}
     if [[ ! ${install_version_python:-} ]]; then
         if install_os_is_centos_7; then
@@ -629,6 +630,7 @@ install_vars_export() {
         install_proprietary_key
         install_version_fedora
         install_version_python
+        install_version_centos
         install_version_rhel
         $(compgen -A variable RADIA_RUN_)
         $(compgen -A variable GITHUB_)

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -97,10 +97,10 @@ $(declare -f install_file_from_stdin)
 cat <<'END_CAT' | install_file_from_stdin 444 root root /etc/profile.d/rs-redhat-base.sh
 : \${RADIA_RUN_SERVER:='$install_server'}
 : \${install_depot_server:='$install_depot_server'}
-: \${install_version_centos:='$install_version_centos'}
+: \${install_version_rhel:='$install_version_rhel'}
 : \${install_version_fedora:='$install_version_fedora'}
 : \${install_version_python:='$install_version_python'}
-export RADIA_RUN_SERVER install_depot_server install_version_centos install_version_fedora install_version_python
+export RADIA_RUN_SERVER install_depot_server install_version_rhel install_version_fedora install_version_python
 END_CAT
 END_SUDO
 }

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -97,11 +97,10 @@ $(declare -f install_file_from_stdin)
 cat <<'END_CAT' | install_file_from_stdin 444 root root /etc/profile.d/rs-redhat-base.sh
 : \${RADIA_RUN_SERVER:='$install_server'}
 : \${install_depot_server:='$install_depot_server'}
-: \${install_version_centos:='$install_version_centos'}
 : \${install_version_rhel:='$install_version_rhel'}
 : \${install_version_fedora:='$install_version_fedora'}
 : \${install_version_python:='$install_version_python'}
-export RADIA_RUN_SERVER install_depot_server install_version_centos install_version_rhel install_version_fedora install_version_python
+export RADIA_RUN_SERVER install_depot_server install_version_rhel install_version_fedora install_version_python
 END_CAT
 END_SUDO
 }

--- a/installers/redhat-base/radiasoft-download.sh
+++ b/installers/redhat-base/radiasoft-download.sh
@@ -97,10 +97,11 @@ $(declare -f install_file_from_stdin)
 cat <<'END_CAT' | install_file_from_stdin 444 root root /etc/profile.d/rs-redhat-base.sh
 : \${RADIA_RUN_SERVER:='$install_server'}
 : \${install_depot_server:='$install_depot_server'}
+: \${install_version_centos:='$install_version_centos'}
 : \${install_version_rhel:='$install_version_rhel'}
 : \${install_version_fedora:='$install_version_fedora'}
 : \${install_version_python:='$install_version_python'}
-export RADIA_RUN_SERVER install_depot_server install_version_rhel install_version_fedora install_version_python
+export RADIA_RUN_SERVER install_depot_server install_version_centos install_version_rhel install_version_fedora install_version_python
 END_CAT
 END_SUDO
 }

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -26,9 +26,9 @@ vagrant_dev_box_add() {
         box=generic/fedora$install_version_fedora
     elif [[ $box == centos ]]; then
         if [[ $_vagrant_dev_host_os == ubuntu ]]; then
-            box=generic/centos${install_version_rhel:-install_version_centos}
+            box=generic/centos$install_version_rhel
         else
-            box=centos/${install_version_rhel:-install_version_centos}
+            box=centos/$install_version_rhel
         fi
     elif [[ $box == almalinux ]]; then
         if [[ $_vagrant_dev_host_os == ubuntu ]]; then

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -26,9 +26,9 @@ vagrant_dev_box_add() {
         box=generic/fedora$install_version_fedora
     elif [[ $box == centos ]]; then
         if [[ $_vagrant_dev_host_os == ubuntu ]]; then
-            box=generic/centos$install_version_rhel
+            box=generic/centos${install_version_rhel:-install_version_centos}
         else
-            box=centos/$install_version_rhel
+            box=centos/${install_version_rhel:-install_version_centos}
         fi
     elif [[ $box == almalinux ]]; then
         if [[ $_vagrant_dev_host_os == ubuntu ]]; then

--- a/installers/vagrant-dev/radiasoft-download.sh
+++ b/installers/vagrant-dev/radiasoft-download.sh
@@ -26,15 +26,15 @@ vagrant_dev_box_add() {
         box=generic/fedora$install_version_fedora
     elif [[ $box == centos ]]; then
         if [[ $_vagrant_dev_host_os == ubuntu ]]; then
-            box=generic/centos$install_version_centos
+            box=generic/centos$install_version_rhel
         else
-            box=centos/$install_version_centos
+            box=centos/$install_version_rhel
         fi
     elif [[ $box == almalinux ]]; then
         if [[ $_vagrant_dev_host_os == ubuntu ]]; then
-            box=generic/alma$install_version_centos
+            box=generic/alma$install_version_rhel
         else
-            box=almalinux/$install_version_centos
+            box=almalinux/$install_version_rhel
         fi
     fi
     if ! vagrant box list | grep -F -q "$box"; then


### PR DESCRIPTION
Presumably, existing `/etc/profile.d/rs-redhat-base.sh` files would need to get updated.